### PR TITLE
Manage html5 boolean attributes

### DIFF
--- a/src/mixt/pyxl/README.md
+++ b/src/mixt/pyxl/README.md
@@ -11,6 +11,7 @@ What we changed:
 - Capitalized classes in `html`, but kept html tags in "mixt" encoding as lowercased
 - Removed `form_error` tag (`<form:error>` is not an html tag)
 - Renamed `html.rawhtml` function to `html.Raw`
+- Manage boolean attributes (specifically without value)
 
 
 You'll find the original README of this library below:

--- a/src/mixt/pyxl/base.py
+++ b/src/mixt/pyxl/base.py
@@ -183,6 +183,36 @@ class Base(object, metaclass=BaseMetaclass):
                         self.__tag__, self.__class__.__name__, value, name, values_enum)
                     raise PyxlException(msg)
 
+            elif attr_type is bool:
+                # Special case for bool.
+                # We can have True:
+                #     In html5, bool attributes can set to an empty string or the attribute name.
+                #     We also accept python True or a string that is 'true' lowercased.
+                #     We force the value to True.
+                # We can have False:
+                #     In html5, bool attributes can set to an empty string or the attribute name
+                #     We also accept python True or a string that is 'true' lowercased.
+                #     We force the value to True.
+                # All other cases generate an error
+
+                if value in ('', name, True):
+                    value = True
+                elif value is False:
+                    value = False
+                else:
+                    str_value = str(value).capitalize()
+                    if str_value == 'True':
+                        value = True
+                    elif str_value  == 'False':
+                        value = False
+                    else:
+                        exc_type, exc_obj, exc_tb = sys.exc_info()
+                        msg = '%s: %s: incorrect value for boolean "%s". expected nothing, ' \
+                              'an empty string, "%s", or True or False, as python bool ' \
+                              'or as string, got %s: %s' % (
+                            self.__tag__, self.__class__.__name__, name, name, type(value), value)
+                        exception = PyxlException(msg)
+                        raise exception.with_traceback(exc_tb)
             else:
                 try:
                     # Validate type of attr and cast to correct type if possible

--- a/src/mixt/pyxl/codec/html_tokenizer.py
+++ b/src/mixt/pyxl/codec/html_tokenizer.py
@@ -128,6 +128,9 @@ class HTMLTokenizer(object):
     def got_attribute(self):
         if self.attribute_name in self.tag.attrs:
             raise ParseError("repeat attribute name %r" % self.attribute_name)
+        if self.attribute_value is None:
+            # special boolean attributes case without values
+            self.attribute_value = True
         self.tag.attrs[self.attribute_name] = self.attribute_value
         self.attribute_name = None
         self.attribute_value = None
@@ -205,6 +208,7 @@ class HTMLTokenizer(object):
             elif c == '=':
                 self.state = State.BEFORE_ATTRIBUTE_VALUE
             elif c == '>':
+                self.got_attribute()
                 self.emit_tag()
                 self.state = State.DATA
             elif c in "\"'<":
@@ -226,6 +230,10 @@ class HTMLTokenizer(object):
                 self.state = State.DATA
             elif c in "\"'<":
                 raise BadCharError(self.state, c)
+            else:
+                self.got_attribute()
+                self.attribute_name = c.lower()
+                self.state = State.ATTRIBUTE_NAME
 
         elif self.state == State.BEFORE_ATTRIBUTE_VALUE:
             if c in '\t\n\f ':

--- a/src/mixt/pyxl/codec/parser.py
+++ b/src/mixt/pyxl/codec/parser.py
@@ -142,24 +142,32 @@ class PyxlParser(HTMLTokenizer):
                         yield part
                     prev_was_python = False
 
-        attr_value = list(format_parts())
-        if len(attr_value) == 1:
-            part = attr_value[0]
-            if type(part) == list:
-                self.output.append(Untokenizer().untokenize(part))
-            else:
-                self.output.append(repr(part))
+        output = []
+
+        if attr_value is True:
+            # special case where we force the value to True for attributes without value
+            output.append('True')
         else:
-            self.output.append('u"".join((')
-            for part in attr_value:
+            attr_value = list(format_parts())
+            if len(attr_value) == 1:
+                part = attr_value[0]
                 if type(part) == list:
-                    self.output.append('str(')
-                    self.output.append(Untokenizer().untokenize(part))
-                    self.output.append(')')
+                    output.append(Untokenizer().untokenize(part))
                 else:
-                    self.output.append(repr(part))
-                self.output.append(', ')
-            self.output.append('))')
+                    output.append(repr(part))
+            else:
+                output.append('u"".join((')
+                for part in attr_value:
+                    if type(part) == list:
+                        output.append('str(')
+                        output.append(Untokenizer().untokenize(part))
+                        output.append(')')
+                    else:
+                        output.append(repr(part))
+                    output.append(', ')
+                output.append('))')
+
+        self.output.extend(output)
 
     @staticmethod
     def _normalize_data_whitespace(data, prev_was_py, next_is_py):

--- a/src/mixt/pyxl/html.py
+++ b/src/mixt/pyxl/html.py
@@ -29,7 +29,11 @@ class HtmlBaseElement(Base, metaclass=HtmlElementMetaclass):
     def _render_attributes(self):
         result = []
         for name, value in self.__attributes__.items():
-            result.extend((' ', name, '="', escape(value), '"'))
+            if self.__attrs__.get(name, None) is bool:
+                if value:
+                    result.extend((' ', name))
+            else:
+                result.extend((' ', name, '="', escape(value), '"'))
         return result
 
 class HtmlElement(HtmlBaseElement):
@@ -165,7 +169,7 @@ class Br(HtmlElementNoChild):
 
 class Button(HtmlElement):
     __attrs__ = {
-        'disabled': str,
+        'disabled': bool,
         'name': str,
         'type': str,
         'value': str,
@@ -267,7 +271,7 @@ class Form(HtmlElement):
         'enctype': str,
         'method': str,
         'name': str,
-        'novalidate': str,
+        'novalidate': bool,
         'target': str,
         }
 
@@ -345,16 +349,16 @@ class Iframe(HtmlElement):
         'width': str,
         # rk: 'allowTransparency' is not in W3C's HTML spec, but it's supported in most modern browsers.
         'allowtransparency': str,
-        'allowfullscreen': str,
+        'allowfullscreen': bool,
         }
 
 class Video(HtmlElement):
     __attrs__ = {
-        'autoplay': str,
+        'autoplay': bool,
         'controls': str,
         'height': str,
-        'loop': str,
-        'muted': str,
+        'loop': bool,
+        'muted': bool,
         'poster': str,
         'preload': str,
         'src': str,
@@ -366,7 +370,7 @@ class Img(HtmlElementNoChild):
         'alt': str,
         'src': str,
         'height': str,
-        'ismap': str,
+        'ismap': bool,
         'longdesc': str,
         'usemap': str,
         'vspace': str,
@@ -378,9 +382,9 @@ class Input(HtmlElementNoChild):
         'accept': str,
         'align': str,
         'alt': str,
-        'autofocus': str,
-        'checked': str,
-        'disabled': str,
+        'autofocus': bool,
+        'checked': bool,
+        'disabled': bool,
         'list': str,
         'max': str,
         'maxlength': str,
@@ -396,9 +400,9 @@ class Input(HtmlElementNoChild):
         'value': str,
         'autocomplete': str,
         'autocorrect': str,
-        'required': str,
+        'required': bool,
         'spellcheck': str,
-        'multiple': str,
+        'multiple': bool,
         }
 
 class Ins(HtmlElement):
@@ -474,7 +478,7 @@ class Object(HtmlElement):
         'codebase': str,
         'codetype': str,
         'data': str,
-        'declare': str,
+        'declare': bool,
         'height': str,
         'hspace': str,
         'name': str,
@@ -490,15 +494,15 @@ class Ol(HtmlElement):
 
 class Optgroup(HtmlElement):
     __attrs__ = {
-        'disabled': str,
+        'disabled': bool,
         'label': str,
         }
 
 class Option(HtmlElement):
     __attrs__ = {
-        'disabled': str,
+        'disabled': bool,
         'label': str,
-        'selected': str,
+        'selected': bool,
         'value': str,
         }
 
@@ -532,9 +536,9 @@ class Samp(HtmlElement):
 
 class Script(HtmlElement):
     __attrs__ = {
-        'async': str,
+        'async': bool,
         'charset': str,
-        'defer': str,
+        'defer': bool,
         'src': str,
         'type': str,
         }
@@ -544,11 +548,11 @@ class Section(HtmlElement):
 
 class Select(HtmlElement):
     __attrs__ = {
-        'disabled': str,
-        'multiple': str,
+        'disabled': bool,
+        'multiple': bool,
         'name': str,
         'size': str,
-        'required': str,
+        'required': bool,
         }
 
 class Small(HtmlElement):
@@ -609,16 +613,16 @@ class Textarea(HtmlElement):
     __attrs__ = {
         'cols': str,
         'rows': str,
-        'disabled': str,
+        'disabled': bool,
         'placeholder': str,
         'name': str,
-        'readonly': str,
+        'readonly': bool,
         'autocorrect': str,
         'autocomplete': str,
         'autocapitalize': str,
         'spellcheck': str,
         'autofocus': str,
-        'required': str,
+        'required': bool,
         }
 
 class Tfoot(HtmlElement):

--- a/tests/pyxl/test_boolean_attributes.py
+++ b/tests/pyxl/test_boolean_attributes.py
@@ -1,0 +1,43 @@
+# coding: mixt
+
+"""Ensure that boolean attributes are correctly managed."""
+
+import pytest
+from mixt.pyxl import html
+from mixt.pyxl.base import PyxlException
+
+
+def test_without_value():
+    assert str(<textarea readonly />) == '<textarea readonly></textarea>'
+    assert str(<textarea readonly/>) == '<textarea readonly></textarea>'
+
+def test_with_empty_value():
+    assert str(<textarea readonly="" />) == '<textarea readonly></textarea>'
+
+def test_with_name_as_value():
+    assert str(<textarea readonly="readonly" />) == '<textarea readonly></textarea>'
+
+def test_with_boolean_true_as_value():
+    assert str(<textarea readonly={True} />) == '<textarea readonly></textarea>'
+
+def test_with_string_true_as_value():
+    assert str(<textarea readonly="true" />) == '<textarea readonly></textarea>'
+
+def test_with_boolean_false_as_value():
+    assert str(<textarea readonly={False} />) == '<textarea></textarea>'
+
+def test_with_string_false_as_value():
+    assert str(<textarea readonly="false" />) == '<textarea></textarea>'
+
+def test_with_other_thing_as_value():
+    with pytest.raises(PyxlException):
+        <textarea readonly="other" />
+
+    with pytest.raises(PyxlException):
+        <textarea readonly=123 />
+
+    with pytest.raises(PyxlException):
+        <textarea readonly={"other"} />
+
+    with pytest.raises(PyxlException):
+        <textarea readonly={123} />


### PR DESCRIPTION
In html 5, a boolean attribute is considered False if not set, and True
if set without value, or if a value is given, it must be an empty string
or the name of the attribute itself.

In addition, we allow True/False or a string which is, lowercased,
"true" or "false".