### PR TITLE
 Allow {**kwargs} in attributes

### DIFF
--- a/src/mixt/pyxl/README.md
+++ b/src/mixt/pyxl/README.md
@@ -12,6 +12,7 @@ What we changed:
 - Removed `form_error` tag (`<form:error>` is not an html tag)
 - Renamed `html.rawhtml` function to `html.Raw`
 - Manage boolean attributes (specifically without value)
+- Allow passing attributes as kwargs `<input type="text" {**someattrs} />`
 
 
 You'll find the original README of this library below:

--- a/src/mixt/pyxl/codec/html_tokenizer.py
+++ b/src/mixt/pyxl/codec/html_tokenizer.py
@@ -277,6 +277,9 @@ class HTMLTokenizer(object):
             if c in '\t\n\f ':
                 self.got_attribute()
                 self.state = State.BEFORE_ATTRIBUTE_NAME
+            elif c == '/':
+                self.got_attribute()
+                self.state = State.SELF_CLOSING_START_TAG
             elif c == '>':
                 self.got_attribute()
                 self.emit_tag()

--- a/tests/pyxl/test_attributes_as_kwargs.py
+++ b/tests/pyxl/test_attributes_as_kwargs.py
@@ -1,0 +1,50 @@
+# coding: mixt
+
+"""Ensure we can pass attributes to tags as kwargs."""
+import pytest
+from mixt.pyxl import html
+from mixt.pyxl.codec.parser import ParseError
+from mixt.pyxl.codec.register import pyxl_decode
+
+
+def test_single_valid_kwargs():
+    kwargs = {'type': 'checkbox', 'value': 'on'}
+
+    # alone
+    assert str(<input {**kwargs}/>) == '<input type="checkbox" value="on" />'
+
+    # after attribute without value
+    assert str(<input required {**kwargs}/>) == '<input required type="checkbox" value="on" />'
+    # after attribute with value
+    assert str(<input name="foo" {**kwargs}/>) == '<input name="foo" type="checkbox" value="on" />'
+    # after attribute with python value
+    assert str(<input name={"foo"} {**kwargs}/>) == '<input name="foo" type="checkbox" value="on" />'
+
+    # before attribute without value
+    assert str(<input {**kwargs} required/>) == '<input required type="checkbox" value="on" />'
+    # before attribute with value
+    assert str(<input {**kwargs} name="foo"/>) == '<input name="foo" type="checkbox" value="on" />'
+    # before attribute with python value
+    assert str(<input {**kwargs} name={"foo"} />) == '<input name="foo" type="checkbox" value="on" />'
+
+def test_many_valid_kwargs():
+    kwargs1 = {'type': 'checkbox'}
+    kwargs2 = {'value': 'on'}
+    assert str(<input
+        name={"foo"}
+        {**kwargs1}
+        required="required"
+        {**kwargs2}
+        placeholder="bar"
+    />) == '<input name="foo" required placeholder="bar" type="checkbox" value="on" />'
+
+def test_invalid_duplicate_arguments():
+    kwargs = {'type': 'checkbox', 'value': 'on'}
+
+    with pytest.raises(TypeError):
+        <input {**kwargs} value="off" />
+
+
+def test_invalid_python():
+    with pytest.raises(ParseError):
+        pyxl_decode(b'<input {"foo"} />')

--- a/tests/pyxl/test_nospace_closing_tag.py
+++ b/tests/pyxl/test_nospace_closing_tag.py
@@ -47,3 +47,17 @@ def test_new_element_with_attributes():
 
     assert str(<Foo name="foo" />) == '<div data-name="foo"></div>'
     assert str(<Foo name="foo"/>) == '<div data-name="foo"></div>'
+
+def test_with_python_value_at_the_end():
+    assert str(<button name={"foo"} />) == '<button name="foo"></button>'
+    assert str(<button name={"foo"}/>) == '<button name="foo"></button>'
+    assert str(<button name={"foo"} ></button>) == '<button name="foo"></button>'
+    assert str(<button name={"foo"}></button>) == '<button name="foo"></button>'
+
+def test_with_python_kwargs_at_the_end():
+    kwargs = {'name': 'foo'}
+    assert str(<button {**kwargs} />) == '<button name="foo"></button>'
+    assert str(<button {**kwargs}/>) == '<button name="foo"></button>'
+    assert str(<button {**kwargs} ></button>) == '<button name="foo"></button>'
+    assert str(<button {**kwargs}></button>) == '<button name="foo"></button>'
+


### PR DESCRIPTION
We can pass many ones but
- as it's converted to a python class creation, an attribute can only be
present once
- kwargs are added after the list of normal attributes