### PR TITLE
Use python typing for attrs type

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mixt
-description =  Write html components directly in python and you have a beautiful but controversial MIXTure 
+description =  Write html components directly in python and you have a beautiful but controversial MIXTure
 long_description = file:README.rst
 version = 0.0.1.dev0
 author = Stéphane "Twidi" Angel
@@ -19,7 +19,7 @@ keywords =
     components
     templating
     web-components
-    react-style 
+    react-style
 url = https://github.com/twidi/mixt
 requires-python = >=3.6
 
@@ -28,7 +28,8 @@ zip_safe = True
 packages = find:
 package_dir =
     =src
-#install_requires =
+install_requires =
+    enforce
 
 [options.packages.find]
 where = src

--- a/src/mixt/pyxl/README.md
+++ b/src/mixt/pyxl/README.md
@@ -14,6 +14,7 @@ What we changed:
 - Manage boolean attributes (specifically without value)
 - Allow passing attributes as kwargs `<input type="text" {**someattrs} />`
 - Use typing to validate attrs, now named props, defined in a ``Props`` class inside tags classes instead of the dict ``__attrs__``
+- Props can now have default value, that are validated
 
 
 You'll find the original README of this library below:

--- a/src/mixt/pyxl/README.md
+++ b/src/mixt/pyxl/README.md
@@ -14,7 +14,7 @@ What we changed:
 - Manage boolean attributes (specifically without value)
 - Allow passing attributes as kwargs `<input type="text" {**someattrs} />`
 - Use typing to validate attrs, now named props, defined in a ``Props`` class inside tags classes instead of the dict ``__attrs__``
-- Props can now have default value, that are validated
+- Props can now have default value, that are validated and returned when calling ``props``
 - Props can be mandatory
 
 

--- a/src/mixt/pyxl/README.md
+++ b/src/mixt/pyxl/README.md
@@ -13,7 +13,7 @@ What we changed:
 - Renamed `html.rawhtml` function to `html.Raw`
 - Manage boolean attributes (specifically without value)
 - Allow passing attributes as kwargs `<input type="text" {**someattrs} />`
-- Use typing to validate attrs, defined in a ``Attrs`` class inside tags classes instead of the dict ``__attrs__``
+- Use typing to validate attrs, now named props, defined in a ``Props`` class inside tags classes instead of the dict ``__attrs__``
 
 
 You'll find the original README of this library below:

--- a/src/mixt/pyxl/README.md
+++ b/src/mixt/pyxl/README.md
@@ -15,6 +15,7 @@ What we changed:
 - Allow passing attributes as kwargs `<input type="text" {**someattrs} />`
 - Use typing to validate attrs, now named props, defined in a ``Props`` class inside tags classes instead of the dict ``__attrs__``
 - Props can now have default value, that are validated
+- Props can be mandatory
 
 
 You'll find the original README of this library below:

--- a/src/mixt/pyxl/README.md
+++ b/src/mixt/pyxl/README.md
@@ -13,6 +13,7 @@ What we changed:
 - Renamed `html.rawhtml` function to `html.Raw`
 - Manage boolean attributes (specifically without value)
 - Allow passing attributes as kwargs `<input type="text" {**someattrs} />`
+- Use typing to validate attrs, defined in a ``Attrs`` class inside tags classes instead of the dict ``__attrs__``
 
 
 You'll find the original README of this library below:

--- a/src/mixt/pyxl/base.py
+++ b/src/mixt/pyxl/base.py
@@ -82,12 +82,26 @@ class BasePropTypes:
         cls._types = get_type_hints(cls)
 
         for name, prop_type in cls._types.items():
+
             if cls.__is_choice__(name):
+
                 if not getattr(cls, name, []):
                     raise PyxlException(f'<{cls.__owner_name__}> must have a list of values for prop `{name}`')
+
                 choices = getattr(cls, name)
                 if not isinstance(choices, Sequence) or isinstance(choices, str):
                     raise PyxlException(f'<{cls.__owner_name__}> must have a list of values for prop `{name}`')
+
+                continue
+
+            default = cls.__default__(name)
+            if default is NotProvided:
+                continue
+
+            try:
+                cls.__validate__(name, default)
+            except PyxlException:
+                raise PyxlException(f'<{cls.__owner_name__}>.{name}: {type(default)} `{default}` is not a valid default value')
 
     @classmethod
     def __validate__(cls, name, value):

--- a/src/mixt/pyxl/base.py
+++ b/src/mixt/pyxl/base.py
@@ -7,7 +7,6 @@
 # it's a difficult dependency to fulfill purely to generate random numbers.
 
 import keyword
-import random
 import sys
 
 from typing import get_type_hints, Sequence
@@ -75,50 +74,7 @@ class BaseMetaclass(type):
 class Base(object, metaclass=BaseMetaclass):
 
     class PropTypes(BasePropTypes):
-        # HTML attributes
-        accesskey: str
-        _class: str
-        dir: str
-        id: str
-        lang: str
-        maxlength: str
-        role: str
-        style: str
-        tabindex: int
-        title: str
-        xmllang: str
-
-        # Microdata HTML attributes
-        itemtype: str
-        itemscope: str
-        itemprop: str
-        itemid: str
-        itemref: str
-
-        # JS attributes
-        onabort: str
-        onblur: str
-        onchange: str
-        onclick: str
-        ondblclick: str
-        onerror: str
-        onfocus: str
-        onkeydown: str
-        onkeypress: str
-        onkeyup: str
-        onload: str
-        onmousedown: str
-        onmouseenter: str
-        onmouseleave: str
-        onmousemove: str
-        onmouseout: str
-        onmouseover: str
-        onmouseup: str
-        onreset: str
-        onresize: str
-        onselect: str
-        onsubmit: str
-        onunload: str
+        pass
 
     def __init__(self, **kwargs):
         self.__props__ = {}
@@ -131,35 +87,8 @@ class Base(object, metaclass=BaseMetaclass):
         self.append_children(children)
         return self
 
-    def get_id(self):
-        eid = self.prop('id')
-        if not eid:
-            eid = 'pyxl%d' % random.randint(0, sys.maxsize)
-            self.set_prop('id', eid)
-        return eid
-
-    def children(self, selector=None, exclude=False):
-        if not selector:
-            return self.__children__
-
-        # filter by class
-        if selector[0] == '.':
-            select = lambda x: selector[1:] in x.get_class()
-
-        # filter by id
-        elif selector[0] == '#':
-            select = lambda x: selector[1:] == x.get_id()
-
-        # filter by tag name
-        else:
-            select = lambda x: x.__class__.__name__ == selector
-
-        if exclude:
-            func = lambda x: not select(x)
-        else:
-            func = select
-
-        return list(filter(func, self.__children__))
+    def children(self):
+        return self.__children__
 
     def append(self, child):
         if type(child) in (list, tuple) or hasattr(child, '__iter__'):
@@ -268,16 +197,6 @@ class Base(object, metaclass=BaseMetaclass):
 
         elif name in self.__props__:
             del self.__props__[name]
-
-    def get_class(self):
-        return self.prop('class', '')
-
-    def add_class(self, xclass):
-        if not xclass: return
-        current_class = self.prop('class')
-        if current_class: current_class += ' ' + xclass
-        else: current_class = xclass
-        self.set_prop('class', current_class)
 
     def append_children(self, children):
         for child in children:

--- a/src/mixt/pyxl/base.py
+++ b/src/mixt/pyxl/base.py
@@ -88,7 +88,9 @@ class BasePropTypes:
 
         for name, prop_type in cls.__types__.items():
 
+            is_mandatory = False
             if issubclass(prop_type, Mandatory):
+                is_mandatory = True
                 prop_type = prop_type.__args__[0]
                 cls.__types__[name] = prop_type
                 cls.__mandatory_props__.add(name)
@@ -103,6 +105,8 @@ class BasePropTypes:
                     raise PyxlException(f'<{cls.__owner_name__}> must have a list of values for prop `{name}`')
 
                 if choices[0] is not NotProvided:
+                    if is_mandatory:
+                        raise PyxlException(f'<{cls.__owner_name__}> cannot have a default value for the mandatory prop `{name}`')
                     cls.__default_props__[name] = choices[0]
 
                 continue
@@ -110,6 +114,9 @@ class BasePropTypes:
             default =  getattr(cls, name, NotProvided)
             if default is NotProvided:
                 continue
+
+            if is_mandatory:
+                raise PyxlException(f'<{cls.__owner_name__}> cannot have a default value for the mandatory prop `{name}`')
 
             try:
                 cls.__validate__(name, default)

--- a/src/mixt/pyxl/browser_hacks.py
+++ b/src/mixt/pyxl/browser_hacks.py
@@ -16,12 +16,12 @@ from .base import Base
 from .utils import escape
 
 class ConditionalComment(Base):
-    class Attrs:
+    class PropTypes:
         cond: str
 
     def _to_list(self, l):
         # allow '&', escape everything else from cond
-        cond = self.__attributes__.get('cond', '')
+        cond = self.__props__.get('cond', '')
         cond = '&'.join(map(escape, cond.split('&')))
 
         l.extend(('<!--[if ', cond, ']>'))
@@ -34,12 +34,12 @@ class ConditionalComment(Base):
 class ConditionalNonComment(Base):
     ''' This is a conditional comment where browsers which don't support conditional comments
         will parse the children by default. '''
-    class Attrs:
+    class PropTypes:
         cond: str
 
     def _to_list(self, l):
         # allow '&', escape everything else from cond
-        cond = self.__attributes__.get('cond', '')
+        cond = self.__props__.get('cond', '')
         cond = '&'.join(map(escape, cond.split('&')))
 
         l.extend(('<!--[if ', cond, ']><!-->'))

--- a/src/mixt/pyxl/browser_hacks.py
+++ b/src/mixt/pyxl/browser_hacks.py
@@ -16,9 +16,8 @@ from .base import Base
 from .utils import escape
 
 class ConditionalComment(Base):
-    __attrs__ = {
-        'cond': str,
-        }
+    class Attrs:
+        cond: str
 
     def _to_list(self, l):
         # allow '&', escape everything else from cond
@@ -35,9 +34,8 @@ class ConditionalComment(Base):
 class ConditionalNonComment(Base):
     ''' This is a conditional comment where browsers which don't support conditional comments
         will parse the children by default. '''
-    __attrs__ = {
-        'cond': str,
-        }
+    class Attrs:
+        cond: str
 
     def _to_list(self, l):
         # allow '&', escape everything else from cond

--- a/src/mixt/pyxl/codec/html_tokenizer.py
+++ b/src/mixt/pyxl/codec/html_tokenizer.py
@@ -128,7 +128,7 @@ class HTMLTokenizer(object):
 
     def got_attribute(self):
         if self.attribute_name in self.tag.attrs:
-            raise ParseError("repeat attribute name %r" % self.attribute_name)
+            raise ParseError("Repeat prop name %r" % self.attribute_name)
         if self.attribute_value is None:
             # special boolean attributes case without values
             self.attribute_value = True

--- a/src/mixt/pyxl/codec/parser.py
+++ b/src/mixt/pyxl/codec/parser.py
@@ -127,14 +127,6 @@ class PyxlParser(HTMLTokenizer):
     def get_token(self):
         return (tokenize.STRING, ''.join(self.output), self.start, self.end, '')
 
-    @staticmethod
-    def safe_attr_name(name):
-        if name == "class":
-            return "xclass"
-        if name == "for":
-            return "xfor"
-        return name.replace('-', '_').replace(':', 'COLON')
-
     def _handle_attr_value(self, attr_value):
         def format_parts():
             prev_was_python = False
@@ -233,7 +225,12 @@ class PyxlParser(HTMLTokenizer):
             if first_attr: first_attr = False
             else: self.output.append(', ')
 
-            self.output.append(self.safe_attr_name(attr_name))
+            try:
+                safe_attr_name = html.Base.Attrs.to_python(attr_name)
+            except NameError:
+                raise ParseError("Invalid attribute name %s" % attr_name, self.start)
+
+            self.output.append(safe_attr_name)
             self.output.append('=')
             self.output.extend(self._handle_attr_value(attr_value))
 

--- a/src/mixt/pyxl/codec/parser.py
+++ b/src/mixt/pyxl/codec/parser.py
@@ -227,7 +227,7 @@ class PyxlParser(HTMLTokenizer):
             else: self.output.append(', ')
 
             try:
-                safe_attr_name = BasePropTypes.to_python(attr_name)
+                safe_attr_name = BasePropTypes.__to_python__(attr_name)
             except NameError:
                 raise ParseError("Invalid prop name %s" % attr_name, self.start)
 

--- a/src/mixt/pyxl/codec/parser.py
+++ b/src/mixt/pyxl/codec/parser.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import tokenize
+from ..base import BasePropTypes
 from .. import html
 from .html_tokenizer import (
         HTMLTokenizer,
@@ -190,9 +191,9 @@ class PyxlParser(HTMLTokenizer):
         self.open_tags.append({'tag':tag, 'row': self.end[0]})
         if tag == 'if':
             if len(attrs) != 1:
-                raise ParseError("if tag only takes one attr called 'cond'", self.end)
+                raise ParseError("if tag only takes one prop called 'cond'", self.end)
             if 'cond' not in attrs:
-                raise ParseError("if tag must contain the 'cond' attr", self.end)
+                raise ParseError("if tag must contain the 'cond' prop", self.end)
 
             self.output.append('html._push_condition(bool(')
             self.output.extend(self._handle_attr_value(attrs['cond']))
@@ -202,7 +203,7 @@ class PyxlParser(HTMLTokenizer):
             return
         elif tag == 'else':
             if len(attrs) != 0:
-                raise ParseError("else tag takes no attrs", self.end)
+                raise ParseError("<else> tag takes no props", self.end)
             if not self.last_thing_was_close_if_tag:
                 raise ParseError("<else> tag must come right after </if>", self.end)
 
@@ -226,9 +227,9 @@ class PyxlParser(HTMLTokenizer):
             else: self.output.append(', ')
 
             try:
-                safe_attr_name = html.Base.Attrs.to_python(attr_name)
+                safe_attr_name = BasePropTypes.to_python(attr_name)
             except NameError:
-                raise ParseError("Invalid attribute name %s" % attr_name, self.start)
+                raise ParseError("Invalid prop name %s" % attr_name, self.start)
 
             self.output.append(safe_attr_name)
             self.output.append('=')

--- a/src/mixt/pyxl/element.py
+++ b/src/mixt/pyxl/element.py
@@ -22,7 +22,7 @@ class Element(Base):
 
         if classes and isinstance(out, Base):
             classes.update(out.get_class().split(' '))
-            out.set_attr('class', ' '.join([_f for _f in classes if _f]))
+            out.set_prop('class', ' '.join([_f for _f in classes if _f]))
 
         return out
 

--- a/src/mixt/pyxl/element.py
+++ b/src/mixt/pyxl/element.py
@@ -4,6 +4,10 @@ from .base import Base
 
 class Element(Base):
 
+    class PropTypes:
+        _class: str
+        id: str
+
     _element = None  # render() output cached by _rendered_element()
 
     def _get_base_element(self):
@@ -25,6 +29,48 @@ class Element(Base):
             out.set_prop('class', ' '.join([_f for _f in classes if _f]))
 
         return out
+
+    def add_class(self, xclass):
+        if not xclass: return
+        current_class = self.prop('class')
+        if current_class: current_class += ' ' + xclass
+        else: current_class = xclass
+        self.set_prop('class', current_class)
+
+    def get_id(self):
+        eid = self.prop('id')
+        if not eid:
+            eid = 'pyxl%d' % random.randint(0, sys.maxsize)
+            self.set_prop('id', eid)
+        return eid
+
+    def get_class(self):
+        return self.prop('class', '')
+
+    def children(self, selector=None, exclude=False):
+        children = super().children()
+
+        if not selector:
+            return children
+
+        # filter by class
+        if selector[0] == '.':
+            select = lambda x: selector[1:] in x.get_class()
+
+        # filter by id
+        elif selector[0] == '#':
+            select = lambda x: selector[1:] == x.get_id()
+
+        # filter by tag name
+        else:
+            select = lambda x: x.__class__.__name__ == selector
+
+        if exclude:
+            func = lambda x: not select(x)
+        else:
+            func = select
+
+        return list(filter(func, children))
 
     def _to_list(self, l):
         self._render_child_to_list(self._get_base_element(), l)

--- a/src/mixt/pyxl/html.py
+++ b/src/mixt/pyxl/html.py
@@ -76,8 +76,8 @@ class HtmlBaseElement(Base, metaclass=HtmlElementMetaclass):
     def _render_attributes(self):
         result = []
         for name, value in self.props.items():
-            html_name = BasePropTypes.to_html(name)
-            if self.PropTypes.type(name) is bool:
+            html_name = BasePropTypes.__to_html__(name)
+            if self.PropTypes.__is_bool__(name):
                 if value:
                     result.extend((' ', html_name))
             else:

--- a/src/mixt/pyxl/html.py
+++ b/src/mixt/pyxl/html.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from .utils import escape
-from .base import Base, BaseMetaclass
+from .base import Base, BaseMetaclass, BasePropTypes
 
 # for backwards compatibility.
 from .browser_hacks import ConditionalComment
@@ -28,9 +28,9 @@ class HtmlElementMetaclass(BaseMetaclass):
 class HtmlBaseElement(Base, metaclass=HtmlElementMetaclass):
     def _render_attributes(self):
         result = []
-        for name, value in self.__attributes__.items():
-            html_name = self.Attrs.to_html(name)
-            if self.Attrs.type(name) is bool:
+        for name, value in self.props.items():
+            html_name = BasePropTypes.to_html(name)
+            if self.PropTypes.type(name) is bool:
                 if value:
                     result.extend((' ', html_name))
             else:
@@ -60,35 +60,35 @@ class HtmlElementNoChild(HtmlBaseElement):
 
 
 class HtmlComment(Base):
-    class Attrs:
+    class PropTypes:
         comment: str
 
     def _to_list(self, l):
         pass
 
 class HtmlDeclaration(Base):
-    class Attrs:
+    class PropTypes:
         decl: str
 
     def _to_list(self, l):
-        l.extend(('<!', self.attr('decl'), '>'))
+        l.extend(('<!', self.prop('decl'), '>'))
 
 class HtmlMarkedDeclaration(Base):
-    class Attrs:
+    class PropTypes:
         decl: str
 
     def _to_list(self, l):
-        l.extend(('<![', self.attr('decl'), ']]>'))
+        l.extend(('<![', self.prop('decl'), ']]>'))
 
 class HtmlMSDeclaration(Base):
-    class Attrs:
+    class PropTypes:
         decl: str
 
     def _to_list(self, l):
-        l.extend(('<![', self.attr('decl'), ']>'))
+        l.extend(('<![', self.prop('decl'), ']>'))
 
 class RawHtml(HtmlElementNoChild):
-    class Attrs:
+    class PropTypes:
         text: str
 
     def _to_list(self, l):
@@ -106,7 +106,7 @@ class Fragment(Base):
             self._render_child_to_list(child, l)
 
 class A(HtmlElement):
-    class Attrs:
+    class PropTypes:
         href: str
         rel: str
         type: str
@@ -124,7 +124,7 @@ class Address(HtmlElement):
     pass
 
 class Area(HtmlElementNoChild):
-    class Attrs:
+    class PropTypes:
         alt: str
         coords: str
         href: str
@@ -138,7 +138,7 @@ class Aside(HtmlElement):
     pass
 
 class Audio(HtmlElement):
-    class Attrs:
+    class PropTypes:
         src: str
 
 class B(HtmlElement):
@@ -148,25 +148,25 @@ class Big(HtmlElement):
    pass
 
 class Blockquote(HtmlElement):
-    class Attrs:
+    class PropTypes:
         cite: str
 
 class Body(HtmlElement):
-    class Attrs:
+    class PropTypes:
         contenteditable: str
 
 class Br(HtmlElementNoChild):
    pass
 
 class Button(HtmlElement):
-    class Attrs:
+    class PropTypes:
         disabled: bool
         name: str
         type: str
         value: str
 
 class Canvas(HtmlElement):
-    class Attrs:
+    class PropTypes:
         height: str
         width: str
 
@@ -180,7 +180,7 @@ class Code(HtmlElement):
    pass
 
 class Col(HtmlElementNoChild):
-    class Attrs:
+    class PropTypes:
         align: str
         char: str
         charoff: int
@@ -189,7 +189,7 @@ class Col(HtmlElementNoChild):
         width: str
 
 class Colgroup(HtmlElement):
-    class Attrs:
+    class PropTypes:
         align: str
         char: str
         charoff: int
@@ -204,12 +204,12 @@ class Dd(HtmlElement):
    pass
 
 class Del(HtmlElement):
-    class Attrs:
+    class PropTypes:
         cite: str
         datetime: str
 
 class Div(HtmlElement):
-   class Attrs:
+   class PropTypes:
         contenteditable: str
 
 class Dfn(HtmlElement):
@@ -225,7 +225,7 @@ class Em(HtmlElement):
    pass
 
 class Embed(HtmlElement):
-    class Attrs:
+    class PropTypes:
         src: str
         width: str
         height: str
@@ -247,7 +247,7 @@ class Footer(HtmlElement):
     pass
 
 class Form(HtmlElement):
-    class Attrs:
+    class PropTypes:
         action: str
         accept: str
         accept_charset: str
@@ -259,7 +259,7 @@ class Form(HtmlElement):
         target: str
 
 class Frame(HtmlElementNoChild):
-    class Attrs:
+    class PropTypes:
         frameborder: str
         longdesc: str
         marginheight: str
@@ -270,7 +270,7 @@ class Frame(HtmlElementNoChild):
         src: str
 
 class Frameset(HtmlElement):
-    class Attrs:
+    class PropTypes:
         rows: str
         cols: str
 
@@ -293,7 +293,7 @@ class H6(HtmlElement):
    pass
 
 class Head(HtmlElement):
-    class Attrs:
+    class PropTypes:
         profile: str
 
 class Header(HtmlElement):
@@ -303,7 +303,7 @@ class Hr(HtmlElementNoChild):
     pass
 
 class Html(HtmlElement):
-    class Attrs:
+    class PropTypes:
         content: str
         scheme: str
         http_equiv: str
@@ -315,7 +315,7 @@ class I(HtmlElement):
    pass
 
 class Iframe(HtmlElement):
-    class Attrs:
+    class PropTypes:
         frameborder: str
         height: str
         longdesc: str
@@ -331,7 +331,7 @@ class Iframe(HtmlElement):
         allowfullscreen: bool
 
 class Video(HtmlElement):
-    class Attrs:
+    class PropTypes:
         autoplay: bool
         controls: str
         height: str
@@ -343,7 +343,7 @@ class Video(HtmlElement):
         width: str
 
 class Img(HtmlElementNoChild):
-    class Attrs:
+    class PropTypes:
         alt: str
         src: str
         height: str
@@ -354,7 +354,7 @@ class Img(HtmlElementNoChild):
         width: str
 
 class Input(HtmlElementNoChild):
-    class Attrs:
+    class PropTypes:
         accept: str
         align: str
         alt: str
@@ -381,7 +381,7 @@ class Input(HtmlElementNoChild):
         multiple: bool
 
 class Ins(HtmlElement):
-    class Attrs:
+    class PropTypes:
         cite: str
         datetime: str
 
@@ -389,7 +389,7 @@ class Kbd(HtmlElement):
     pass
 
 class Label(HtmlElement):
-    class Attrs:
+    class PropTypes:
         _for: str
 
 class Legend(HtmlElement):
@@ -399,7 +399,7 @@ class Li(HtmlElement):
    pass
 
 class Link(HtmlElementNoChild):
-    class Attrs:
+    class PropTypes:
         charset: str
         href: str
         hreflang: str
@@ -413,15 +413,15 @@ class Link(HtmlElementNoChild):
 class Main(HtmlElement):
     # we are not enforcing the w3 spec of one and only one main element on the
     # page
-    class Attrs:
+    class PropTypes:
         role: str
 
 class Map(HtmlElement):
-    class Attrs:
+    class PropTypes:
         name: str
 
 class Meta(HtmlElementNoChild):
-    class Attrs:
+    class PropTypes:
         content: str
         http_equiv: str
         name: str
@@ -439,7 +439,7 @@ class Noscript(HtmlElement):
    pass
 
 class Object(HtmlElement):
-    class Attrs:
+    class PropTypes:
         align: str
         archive: str
         border: str
@@ -461,12 +461,12 @@ class Ol(HtmlElement):
    pass
 
 class Optgroup(HtmlElement):
-    class Attrs:
+    class PropTypes:
         disabled: bool
         label: str
 
 class Option(HtmlElement):
-    class Attrs:
+    class PropTypes:
         disabled: bool
         label: str
         selected: bool
@@ -476,7 +476,7 @@ class P(HtmlElement):
    pass
 
 class Param(HtmlElement):
-    class Attrs:
+    class PropTypes:
         name: str
         type: str
         value: str
@@ -486,19 +486,19 @@ class Pre(HtmlElement):
    pass
 
 class Progress(HtmlElement):
-    class Attrs:
+    class PropTypes:
         max: int
         value: int
 
 class Q(HtmlElement):
-    class Attrs:
+    class PropTypes:
         cite: str
 
 class Samp(HtmlElement):
    pass
 
 class Script(HtmlElement):
-    class Attrs:
+    class PropTypes:
         async: bool
         charset: str
         defer: bool
@@ -509,7 +509,7 @@ class Section(HtmlElement):
     pass
 
 class Select(HtmlElement):
-    class Attrs:
+    class PropTypes:
         disabled: bool
         multiple: bool
         name: str
@@ -526,7 +526,7 @@ class Strong(HtmlElement):
    pass
 
 class Style(HtmlElement):
-    class Attrs:
+    class PropTypes:
         media: str
         type: str
 
@@ -537,7 +537,7 @@ class Sup(HtmlElement):
    pass
 
 class Table(HtmlElement):
-    class Attrs:
+    class PropTypes:
         border: str
         cellpadding: str
         cellspacing: str
@@ -547,14 +547,14 @@ class Table(HtmlElement):
         width: str
 
 class Tbody(HtmlElement):
-    class Attrs:
+    class PropTypes:
         align: str
         char: str
         charoff: str
         valign: str
 
 class Td(HtmlElement):
-    class Attrs:
+    class PropTypes:
         abbr: str
         align: str
         axis: str
@@ -567,7 +567,7 @@ class Td(HtmlElement):
         valign: str
 
 class Textarea(HtmlElement):
-    class Attrs:
+    class PropTypes:
         cols: str
         rows: str
         disabled: bool
@@ -582,14 +582,14 @@ class Textarea(HtmlElement):
         required: bool
 
 class Tfoot(HtmlElement):
-    class Attrs:
+    class PropTypes:
         align: str
         char: str
         charoff: str
         valign: str
 
 class Th(HtmlElement):
-    class Attrs:
+    class PropTypes:
         abbr: str
         align: str
         axis: str
@@ -601,21 +601,21 @@ class Th(HtmlElement):
         valign: str
 
 class Thead(HtmlElement):
-    class Attrs:
+    class PropTypes:
         align: str
         char: str
         charoff: str
         valign: str
 
 class Time(HtmlElement):
-    class Attrs:
+    class PropTypes:
         datetime: str
 
 class Title(HtmlElement):
    pass
 
 class Tr(HtmlElement):
-    class Attrs:
+    class PropTypes:
         align: str
         char: str
         charoff: str

--- a/src/mixt/pyxl/html.py
+++ b/src/mixt/pyxl/html.py
@@ -26,6 +26,53 @@ class HtmlElementMetaclass(BaseMetaclass):
 
 
 class HtmlBaseElement(Base, metaclass=HtmlElementMetaclass):
+
+    class PropTypes:
+        # HTML attributes
+        accesskey: str
+        _class: str
+        dir: str
+        id: str
+        lang: str
+        maxlength: str
+        role: str
+        style: str
+        tabindex: int
+        title: str
+        xmllang: str
+
+        # Microdata HTML attributes
+        itemtype: str
+        itemscope: str
+        itemprop: str
+        itemid: str
+        itemref: str
+
+        # JS attributes
+        onabort: str
+        onblur: str
+        onchange: str
+        onclick: str
+        ondblclick: str
+        onerror: str
+        onfocus: str
+        onkeydown: str
+        onkeypress: str
+        onkeyup: str
+        onload: str
+        onmousedown: str
+        onmouseenter: str
+        onmouseleave: str
+        onmousemove: str
+        onmouseout: str
+        onmouseover: str
+        onmouseup: str
+        onreset: str
+        onresize: str
+        onselect: str
+        onsubmit: str
+        onunload: str
+
     def _render_attributes(self):
         result = []
         for name, value in self.props.items():

--- a/src/mixt/pyxl/html.py
+++ b/src/mixt/pyxl/html.py
@@ -29,11 +29,12 @@ class HtmlBaseElement(Base, metaclass=HtmlElementMetaclass):
     def _render_attributes(self):
         result = []
         for name, value in self.__attributes__.items():
-            if self.__attrs__.get(name, None) is bool:
+            html_name = self.Attrs.to_html(name)
+            if self.Attrs.type(name) is bool:
                 if value:
-                    result.extend((' ', name))
+                    result.extend((' ', html_name))
             else:
-                result.extend((' ', name, '="', escape(value), '"'))
+                result.extend((' ', html_name, '="', escape(value), '"'))
         return result
 
 class HtmlElement(HtmlBaseElement):
@@ -59,41 +60,36 @@ class HtmlElementNoChild(HtmlBaseElement):
 
 
 class HtmlComment(Base):
-    __attrs__ = {
-        'comment': str,
-        }
+    class Attrs:
+        comment: str
 
     def _to_list(self, l):
         pass
 
 class HtmlDeclaration(Base):
-    __attrs__ = {
-        'decl': str,
-        }
+    class Attrs:
+        decl: str
 
     def _to_list(self, l):
         l.extend(('<!', self.attr('decl'), '>'))
 
 class HtmlMarkedDeclaration(Base):
-    __attrs__ = {
-        'decl': str,
-        }
+    class Attrs:
+        decl: str
 
     def _to_list(self, l):
         l.extend(('<![', self.attr('decl'), ']]>'))
 
 class HtmlMSDeclaration(Base):
-    __attrs__ = {
-        'decl': str,
-        }
+    class Attrs:
+        decl: str
 
     def _to_list(self, l):
         l.extend(('<![', self.attr('decl'), ']>'))
 
 class RawHtml(HtmlElementNoChild):
-    __attrs__= {
-        'text': str,
-        }
+    class Attrs:
+        text: str
 
     def _to_list(self, l):
         if not isinstance(self.text, str):
@@ -110,14 +106,13 @@ class Fragment(Base):
             self._render_child_to_list(child, l)
 
 class A(HtmlElement):
-    __attrs__ = {
-        'href': str,
-        'rel': str,
-        'type': str,
-        'name': str,
-        'target': str,
-        'download': str,
-        }
+    class Attrs:
+        href: str
+        rel: str
+        type: str
+        name: str
+        target: str
+        download: str
 
 class Abbr(HtmlElement):
     pass
@@ -129,13 +124,12 @@ class Address(HtmlElement):
     pass
 
 class Area(HtmlElementNoChild):
-    __attrs__ = {
-        'alt': str,
-        'coords': str,
-        'href': str,
-        'nohref': str,
-        'target': str,
-        }
+    class Attrs:
+        alt: str
+        coords: str
+        href: str
+        nohref: str
+        target: str
 
 class Article(HtmlElement):
     pass
@@ -144,9 +138,8 @@ class Aside(HtmlElement):
     pass
 
 class Audio(HtmlElement):
-    __attrs__ = {
-        'src': str
-        }
+    class Attrs:
+        src: str
 
 class B(HtmlElement):
    pass
@@ -155,31 +148,27 @@ class Big(HtmlElement):
    pass
 
 class Blockquote(HtmlElement):
-    __attrs__ = {
-        'cite': str,
-        }
+    class Attrs:
+        cite: str
 
 class Body(HtmlElement):
-    __attrs__ = {
-        'contenteditable': str,
-        }
+    class Attrs:
+        contenteditable: str
 
 class Br(HtmlElementNoChild):
    pass
 
 class Button(HtmlElement):
-    __attrs__ = {
-        'disabled': bool,
-        'name': str,
-        'type': str,
-        'value': str,
-        }
+    class Attrs:
+        disabled: bool
+        name: str
+        type: str
+        value: str
 
 class Canvas(HtmlElement):
-    __attrs__ = {
-        'height': str,
-        'width': str,
-        }
+    class Attrs:
+        height: str
+        width: str
 
 class Caption(HtmlElement):
    pass
@@ -191,24 +180,22 @@ class Code(HtmlElement):
    pass
 
 class Col(HtmlElementNoChild):
-    __attrs__ = {
-        'align': str,
-        'char': str,
-        'charoff': int,
-        'span': int,
-        'valign': str,
-        'width': str,
-        }
+    class Attrs:
+        align: str
+        char: str
+        charoff: int
+        span: int
+        valign: str
+        width: str
 
 class Colgroup(HtmlElement):
-    __attrs__ = {
-        'align': str,
-        'char': str,
-        'charoff': int,
-        'span': int,
-        'valign': str,
-        'width': str,
-        }
+    class Attrs:
+        align: str
+        char: str
+        charoff: int
+        span: int
+        valign: str
+        width: str
 
 class Datalist(HtmlElement):
     pass
@@ -217,15 +204,13 @@ class Dd(HtmlElement):
    pass
 
 class Del(HtmlElement):
-    __attrs__ = {
-        'cite': str,
-        'datetime': str,
-        }
+    class Attrs:
+        cite: str
+        datetime: str
 
 class Div(HtmlElement):
-   __attrs__ = {
-        'contenteditable': str,
-       }
+   class Attrs:
+        contenteditable: str
 
 class Dfn(HtmlElement):
    pass
@@ -240,15 +225,14 @@ class Em(HtmlElement):
    pass
 
 class Embed(HtmlElement):
-    __attrs__ = {
-        'src': str,
-        'width': str,
-        'height': str,
-        'allowscriptaccess': str,
-        'allowfullscreen': str,
-        'name': str,
-        'type': str,
-        }
+    class Attrs:
+        src: str
+        width: str
+        height: str
+        allowscriptaccess: str
+        allowfullscreen: str
+        name: str
+        type: str
 
 class Figure(HtmlElement):
    pass
@@ -263,35 +247,32 @@ class Footer(HtmlElement):
     pass
 
 class Form(HtmlElement):
-    __attrs__ = {
-        'action': str,
-        'accept': str,
-        'accept-charset': str,
-        'autocomplete': str,
-        'enctype': str,
-        'method': str,
-        'name': str,
-        'novalidate': bool,
-        'target': str,
-        }
+    class Attrs:
+        action: str
+        accept: str
+        accept_charset: str
+        autocomplete: str
+        enctype: str
+        method: str
+        name: str
+        novalidate: bool
+        target: str
 
 class Frame(HtmlElementNoChild):
-    __attrs__ = {
-        'frameborder': str,
-        'longdesc': str,
-        'marginheight': str,
-        'marginwidth': str,
-        'name': str,
-        'noresize': str,
-        'scrolling': str,
-        'src': str,
-        }
+    class Attrs:
+        frameborder: str
+        longdesc: str
+        marginheight: str
+        marginwidth: str
+        name: str
+        noresize: str
+        scrolling: str
+        src: str
 
 class Frameset(HtmlElement):
-    __attrs__ = {
-        'rows': str,
-        'cols': str,
-        }
+    class Attrs:
+        rows: str
+        cols: str
 
 class H1(HtmlElement):
    pass
@@ -312,9 +293,8 @@ class H6(HtmlElement):
    pass
 
 class Head(HtmlElement):
-    __attrs__ = {
-        'profile': str,
-        }
+    class Attrs:
+        profile: str
 
 class Header(HtmlElement):
     pass
@@ -323,101 +303,94 @@ class Hr(HtmlElementNoChild):
     pass
 
 class Html(HtmlElement):
-    __attrs__ = {
-        'content': str,
-        'scheme': str,
-        'http-equiv': str,
-        'xmlns': str,
-        'xmlns:og': str,
-        'xmlns:fb': str,
-        }
+    class Attrs:
+        content: str
+        scheme: str
+        http_equiv: str
+        xmlns: str
+        xmlns__og: str
+        xmlns__fb: str
 
 class I(HtmlElement):
    pass
 
 class Iframe(HtmlElement):
-    __attrs__ = {
-        'frameborder': str,
-        'height': str,
-        'longdesc': str,
-        'marginheight': str,
-        'marginwidth': str,
-        'name': str,
-        'sandbox': str,
-        'scrolling': str,
-        'src': str,
-        'width': str,
+    class Attrs:
+        frameborder: str
+        height: str
+        longdesc: str
+        marginheight: str
+        marginwidth: str
+        name: str
+        sandbox: str
+        scrolling: str
+        src: str
+        width: str
         # rk: 'allowTransparency' is not in W3C's HTML spec, but it's supported in most modern browsers.
-        'allowtransparency': str,
-        'allowfullscreen': bool,
-        }
+        allowtransparency: str
+        allowfullscreen: bool
 
 class Video(HtmlElement):
-    __attrs__ = {
-        'autoplay': bool,
-        'controls': str,
-        'height': str,
-        'loop': bool,
-        'muted': bool,
-        'poster': str,
-        'preload': str,
-        'src': str,
-        'width': str,
-        }
+    class Attrs:
+        autoplay: bool
+        controls: str
+        height: str
+        loop: bool
+        muted: bool
+        poster: str
+        preload: str
+        src: str
+        width: str
 
 class Img(HtmlElementNoChild):
-    __attrs__ = {
-        'alt': str,
-        'src': str,
-        'height': str,
-        'ismap': bool,
-        'longdesc': str,
-        'usemap': str,
-        'vspace': str,
-        'width': str,
-        }
+    class Attrs:
+        alt: str
+        src: str
+        height: str
+        ismap: bool
+        longdesc: str
+        usemap: str
+        vspace: str
+        width: str
 
 class Input(HtmlElementNoChild):
-    __attrs__ = {
-        'accept': str,
-        'align': str,
-        'alt': str,
-        'autofocus': bool,
-        'checked': bool,
-        'disabled': bool,
-        'list': str,
-        'max': str,
-        'maxlength': str,
-        'min': str,
-        'name': str,
-        'pattern': str,
-        'placeholder': str,
-        'readonly': str,
-        'size': str,
-        'src': str,
-        'step': str,
-        'type': str,
-        'value': str,
-        'autocomplete': str,
-        'autocorrect': str,
-        'required': bool,
-        'spellcheck': str,
-        'multiple': bool,
-        }
+    class Attrs:
+        accept: str
+        align: str
+        alt: str
+        autofocus: bool
+        checked: bool
+        disabled: bool
+        list: str
+        max: str
+        maxlength: str
+        min: str
+        name: str
+        pattern: str
+        placeholder: str
+        readonly: str
+        size: str
+        src: str
+        step: str
+        type: str
+        value: str
+        autocomplete: str
+        autocorrect: str
+        required: bool
+        spellcheck: str
+        multiple: bool
 
 class Ins(HtmlElement):
-    __attrs__ = {
-        'cite': str,
-        'datetime': str,
-        }
+    class Attrs:
+        cite: str
+        datetime: str
 
 class Kbd(HtmlElement):
     pass
 
 class Label(HtmlElement):
-    __attrs__ = {
-        'for': str,
-        }
+    class Attrs:
+        _for: str
 
 class Legend(HtmlElement):
    pass
@@ -426,39 +399,35 @@ class Li(HtmlElement):
    pass
 
 class Link(HtmlElementNoChild):
-    __attrs__ = {
-        'charset': str,
-        'href': str,
-        'hreflang': str,
-        'media': str,
-        'rel': str,
-        'rev': str,
-        'sizes': str,
-        'target': str,
-        'type': str,
-        }
+    class Attrs:
+        charset: str
+        href: str
+        hreflang: str
+        media: str
+        rel: str
+        rev: str
+        sizes: str
+        target: str
+        type: str
 
 class Main(HtmlElement):
     # we are not enforcing the w3 spec of one and only one main element on the
     # page
-    __attrs__ = {
-        'role': str,
-    }
+    class Attrs:
+        role: str
 
 class Map(HtmlElement):
-    __attrs__ = {
-        'name': str,
-        }
+    class Attrs:
+        name: str
 
 class Meta(HtmlElementNoChild):
-    __attrs__ = {
-        'content': str,
-        'http-equiv': str,
-        'name': str,
-        'property': str,
-        'scheme': str,
-        'charset': str,
-        }
+    class Attrs:
+        content: str
+        http_equiv: str
+        name: str
+        property: str
+        scheme: str
+        charset: str
 
 class Nav(HtmlElement):
     pass
@@ -470,90 +439,82 @@ class Noscript(HtmlElement):
    pass
 
 class Object(HtmlElement):
-    __attrs__ = {
-        'align': str,
-        'archive': str,
-        'border': str,
-        'classid': str,
-        'codebase': str,
-        'codetype': str,
-        'data': str,
-        'declare': bool,
-        'height': str,
-        'hspace': str,
-        'name': str,
-        'standby': str,
-        'type': str,
-        'usemap': str,
-        'vspace': str,
-        'width': str,
-        }
+    class Attrs:
+        align: str
+        archive: str
+        border: str
+        classid: str
+        codebase: str
+        codetype: str
+        data: str
+        declare: bool
+        height: str
+        hspace: str
+        name: str
+        standby: str
+        type: str
+        usemap: str
+        vspace: str
+        width: str
 
 class Ol(HtmlElement):
    pass
 
 class Optgroup(HtmlElement):
-    __attrs__ = {
-        'disabled': bool,
-        'label': str,
-        }
+    class Attrs:
+        disabled: bool
+        label: str
 
 class Option(HtmlElement):
-    __attrs__ = {
-        'disabled': bool,
-        'label': str,
-        'selected': bool,
-        'value': str,
-        }
+    class Attrs:
+        disabled: bool
+        label: str
+        selected: bool
+        value: str
 
 class P(HtmlElement):
    pass
 
 class Param(HtmlElement):
-    __attrs__ = {
-        'name': str,
-        'type': str,
-        'value': str,
-        'valuetype': str,
-        }
+    class Attrs:
+        name: str
+        type: str
+        value: str
+        valuetype: str
 
 class Pre(HtmlElement):
    pass
 
 class Progress(HtmlElement):
-    __attrs__ = {
-        'max': int,
-        'value': int,
-    }
+    class Attrs:
+        max: int
+        value: int
 
 class Q(HtmlElement):
-    __attrs__ = {
-        'cite': str,
-        }
+    class Attrs:
+        cite: str
 
 class Samp(HtmlElement):
    pass
 
 class Script(HtmlElement):
-    __attrs__ = {
-        'async': bool,
-        'charset': str,
-        'defer': bool,
-        'src': str,
-        'type': str,
-        }
+    class Attrs:
+        async: bool
+        charset: str
+        defer: bool
+        src: str
+        type: str
 
 class Section(HtmlElement):
     pass
 
 class Select(HtmlElement):
-    __attrs__ = {
-        'disabled': bool,
-        'multiple': bool,
-        'name': str,
-        'size': str,
-        'required': bool,
-        }
+    class Attrs:
+        disabled: bool
+        multiple: bool
+        name: str
+        size: str
+        required: bool
 
 class Small(HtmlElement):
    pass
@@ -565,10 +526,9 @@ class Strong(HtmlElement):
    pass
 
 class Style(HtmlElement):
-    __attrs__ = {
-        'media': str,
-        'type': str,
-        }
+    class Attrs:
+        media: str
+        type: str
 
 class Sub(HtmlElement):
    pass
@@ -577,98 +537,89 @@ class Sup(HtmlElement):
    pass
 
 class Table(HtmlElement):
-    __attrs__ = {
-        'border': str,
-        'cellpadding': str,
-        'cellspacing': str,
-        'frame': str,
-        'rules': str,
-        'summary': str,
-        'width': str,
-        }
+    class Attrs:
+        border: str
+        cellpadding: str
+        cellspacing: str
+        frame: str
+        rules: str
+        summary: str
+        width: str
 
 class Tbody(HtmlElement):
-    __attrs__ = {
-        'align': str,
-        'char': str,
-        'charoff': str,
-        'valign': str,
-        }
+    class Attrs:
+        align: str
+        char: str
+        charoff: str
+        valign: str
 
 class Td(HtmlElement):
-    __attrs__ = {
-        'abbr': str,
-        'align': str,
-        'axis': str,
-        'char': str,
-        'charoff': str,
-        'colspan': str,
-        'headers': str,
-        'rowspan': str,
-        'scope': str,
-        'valign': str,
-        }
+    class Attrs:
+        abbr: str
+        align: str
+        axis: str
+        char: str
+        charoff: str
+        colspan: str
+        headers: str
+        rowspan: str
+        scope: str
+        valign: str
 
 class Textarea(HtmlElement):
-    __attrs__ = {
-        'cols': str,
-        'rows': str,
-        'disabled': bool,
-        'placeholder': str,
-        'name': str,
-        'readonly': bool,
-        'autocorrect': str,
-        'autocomplete': str,
-        'autocapitalize': str,
-        'spellcheck': str,
-        'autofocus': str,
-        'required': bool,
-        }
+    class Attrs:
+        cols: str
+        rows: str
+        disabled: bool
+        placeholder: str
+        name: str
+        readonly: bool
+        autocorrect: str
+        autocomplete: str
+        autocapitalize: str
+        spellcheck: str
+        autofocus: str
+        required: bool
 
 class Tfoot(HtmlElement):
-    __attrs__ = {
-        'align': str,
-        'char': str,
-        'charoff': str,
-        'valign': str,
-        }
+    class Attrs:
+        align: str
+        char: str
+        charoff: str
+        valign: str
 
 class Th(HtmlElement):
-    __attrs__ = {
-        'abbr': str,
-        'align': str,
-        'axis': str,
-        'char': str,
-        'charoff': str,
-        'colspan': str,
-        'rowspan': str,
-        'scope': str,
-        'valign': str,
-        }
+    class Attrs:
+        abbr: str
+        align: str
+        axis: str
+        char: str
+        charoff: str
+        colspan: str
+        rowspan: str
+        scope: str
+        valign: str
 
 class Thead(HtmlElement):
-    __attrs__ = {
-        'align': str,
-        'char': str,
-        'charoff': str,
-        'valign': str,
-        }
+    class Attrs:
+        align: str
+        char: str
+        charoff: str
+        valign: str
 
 class Time(HtmlElement):
-    __attrs__ = {
-        'datetime': str,
-        }
+    class Attrs:
+        datetime: str
 
 class Title(HtmlElement):
    pass
 
 class Tr(HtmlElement):
-    __attrs__ = {
-        'align': str,
-        'char': str,
-        'charoff': str,
-        'valign': str,
-        }
+    class Attrs:
+        align: str
+        char: str
+        charoff: str
+        valign: str
 
 class Tt(HtmlElement):
     pass

--- a/tests/pyxl/original/test_basic.py
+++ b/tests/pyxl/original/test_basic.py
@@ -1,8 +1,9 @@
 # coding: mixt
+
 import pytest
 
 from mixt.pyxl import html
-from mixt.pyxl.base import PyxlException, Base
+from mixt.pyxl.base import PyxlException, Base, Choices
 
 def test_basics():
     assert str(<div />) == '<div></div>'
@@ -39,9 +40,8 @@ def test_decl():
 
 def test_enum_attrs():
     class Foo(Base):
-        __attrs__ = {
-            'value': ['a', 'b'],
-        }
+        class Attrs:
+            value: Choices = ['a', 'b']
 
         def _to_list(self, l):
             pass
@@ -55,9 +55,8 @@ def test_enum_attrs():
         <Foo value="c" />
 
     class Bar(Base):
-        __attrs__ = {
-            'value': ['a', None, 'b'],
-        }
+        class Attrs:
+            value: Choices = ['a', None, 'b']
 
         def _to_list(self, l):
             pass
@@ -69,11 +68,29 @@ def test_enum_attrs():
         <Bar />.value
 
     class Baz(Base):
-        __attrs__ = {
-            'value': [None, 'a', 'b'],
-        }
+        class Attrs:
+            value: Choices = [None, 'a', 'b']
 
         def _to_list(self, l):
             pass
 
     assert (<Baz />.value) == None
+
+
+def test_special_attributes():
+    class Foo(html.HtmlElement):
+        class Attrs:
+            _def: str
+            foo_bar__baz: str
+
+    # using "html" type attribute names
+    tag = <Foo def='fed' foo-bar:baz='qux' />
+    assert str(tag) == '<foo def="fed" foo-bar:baz="qux"></foo>'
+    assert tag._def == 'fed'
+    assert tag.foo_bar__baz == 'qux'
+
+    # using "python" type attributes names
+    tag = <Foo _def='fed' foo_bar__baz='qux' />
+    assert str(tag) == '<foo def="fed" foo-bar:baz="qux"></foo>'
+    assert tag._def == 'fed'
+    assert tag.foo_bar__baz == 'qux'

--- a/tests/pyxl/original/test_basic.py
+++ b/tests/pyxl/original/test_basic.py
@@ -38,37 +38,37 @@ def test_decl():
     assert (str(<script><![CDATA[<div><div>]]></script>)
         == '<script><![CDATA[<div><div>]]></script>')
 
-def test_enum_attrs():
+def test_enum_prop():
     class Foo(Base):
-        class Attrs:
+        class PropTypes:
             value: Choices = ['a', 'b']
 
         def _to_list(self, l):
             pass
 
-    assert (<Foo />.attr('value')) == 'a'
+    assert (<Foo />.prop('value')) == 'a'
     assert (<Foo />.value) == 'a'
-    assert (<Foo value="b" />.attr('value')) == 'b'
+    assert (<Foo value="b" />.prop('value')) == 'b'
     assert (<Foo value="b" />.value) == 'b'
 
     with pytest.raises(PyxlException):
         <Foo value="c" />
 
     class Bar(Base):
-        class Attrs:
+        class PropTypes:
             value: Choices = ['a', None, 'b']
 
         def _to_list(self, l):
             pass
 
     with pytest.raises(PyxlException):
-        <Bar />.attr('value')
+        <Bar />.prop('value')
 
     with pytest.raises(PyxlException):
         <Bar />.value
 
     class Baz(Base):
-        class Attrs:
+        class PropTypes:
             value: Choices = [None, 'a', 'b']
 
         def _to_list(self, l):
@@ -77,19 +77,19 @@ def test_enum_attrs():
     assert (<Baz />.value) == None
 
 
-def test_special_attributes():
+def test_special_prop_names():
     class Foo(html.HtmlElement):
-        class Attrs:
+        class PropTypes:
             _def: str
             foo_bar__baz: str
 
-    # using "html" type attribute names
+    # using "html" type props names
     tag = <Foo def='fed' foo-bar:baz='qux' />
     assert str(tag) == '<foo def="fed" foo-bar:baz="qux"></foo>'
     assert tag._def == 'fed'
     assert tag.foo_bar__baz == 'qux'
 
-    # using "python" type attributes names
+    # using "python" type props names
     tag = <Foo _def='fed' foo_bar__baz='qux' />
     assert str(tag) == '<foo def="fed" foo-bar:baz="qux"></foo>'
     assert tag._def == 'fed'

--- a/tests/pyxl/test_complex_proptypes.py
+++ b/tests/pyxl/test_complex_proptypes.py
@@ -1,0 +1,109 @@
+# coding: mixt
+
+"""Ensure that complex proptypes are correctly validated."""
+
+import pytest
+from mixt.pyxl import html
+from mixt.pyxl.base import Base, PyxlException, NotProvided
+
+from typing import *
+
+
+class DummyBase(Base):
+    def _to_list(self, l):
+        pass
+
+
+def test_simple_union():
+
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Union[float, int]
+
+    assert (<Foo value={1} />.value) == 1
+    assert (<Foo value={1.1} />.value) == 1.1
+
+    with pytest.raises(PyxlException):
+        <Foo value={"foo"} />
+
+    with pytest.raises(PyxlException):
+        <Foo value="foo" />
+
+    with pytest.raises(PyxlException):
+        <Foo value="1" />
+
+    with pytest.raises(PyxlException):
+        <Foo value=1 />
+
+    with pytest.raises(PyxlException):
+        <Foo value={None} />
+
+    with pytest.raises(AttributeError):
+        <Foo value={NotProvided} />.value
+
+
+def test_user_class():
+
+    class User: ...
+
+    class Hero(User): ...
+
+    class Animal: ...
+
+    class Foo(DummyBase):
+        class PropTypes:
+            user: User
+
+    user = User()
+    hero = Hero()
+    animal = Animal()
+
+    assert (<Foo user={user} />.user) == user
+    assert (<Foo user={hero} />.user) == hero
+
+    with pytest.raises(PyxlException):
+        <Foo user={animal} />
+
+    with pytest.raises(PyxlException):
+        <Foo user={None} />
+
+    with pytest.raises(AttributeError):
+        <Foo user={NotProvided} />.user
+
+    with pytest.raises(PyxlException):
+        <Foo user="john" />
+
+
+
+def test_complex_union():
+
+    class User: ...
+
+    class Hero(User): ...
+
+    class Animal: ...
+
+
+    class Foo(DummyBase):
+        class PropTypes:
+            user: Union[User, str]
+
+    user = User()
+    hero = Hero()
+    animal = Animal()
+
+    assert (<Foo user={user} />.user) == user
+    assert (<Foo user="john" />.user) == "john"
+    assert (<Foo user={"john"} />.user) == "john"
+
+    with pytest.raises(PyxlException):
+        <Foo user={animal} />
+
+    with pytest.raises(PyxlException):
+        <Foo user={None} />
+
+    with pytest.raises(AttributeError):
+        <Foo user={NotProvided} />.user
+
+    with pytest.raises(PyxlException):
+        <Foo user={123} />

--- a/tests/pyxl/test_default_props_values.py
+++ b/tests/pyxl/test_default_props_values.py
@@ -4,7 +4,7 @@
 
 import pytest
 from mixt.pyxl import html
-from mixt.pyxl.base import Base, PyxlException
+from mixt.pyxl.base import Base, PyxlException, Choices, NotProvided
 
 from typing import *
 
@@ -47,3 +47,17 @@ def test_invalid_default_value_complex_type():
         class Foo(DummyBase):
             class PropTypes:
                 value: Union[int, float] = "foo"
+
+def test_default_are_returned():
+    class Foo(DummyBase):
+        class PropTypes:
+            value1: int
+            value2: str = "foo"
+            value3: Choices = [1, 2, 3]
+            value4: str = NotProvided
+
+    assert (<Foo />.props) == {'value2': 'foo', 'value3': 1}
+    assert (<Foo value1={123} />.props) == {'value1': 123, 'value2': 'foo', 'value3': 1}
+    assert (<Foo value1={123} value2="bar" />.props) == {'value1': 123, 'value2': 'bar', 'value3': 1}
+    assert (<Foo value1={123} value2="bar" value3={2} />.props) == {'value1': 123, 'value2': 'bar', 'value3': 2}
+    assert (<Foo value1={123} value2="bar" value3={2} value4="baz" />.props) == {'value1': 123, 'value2': 'bar', 'value3': 2, 'value4': 'baz'}

--- a/tests/pyxl/test_default_props_values.py
+++ b/tests/pyxl/test_default_props_values.py
@@ -4,7 +4,7 @@
 
 import pytest
 from mixt.pyxl import html
-from mixt.pyxl.base import Base, PyxlException, Choices, NotProvided
+from mixt.pyxl.base import Base, PyxlException, Choices, NotProvided, Mandatory
 
 from typing import *
 
@@ -61,3 +61,13 @@ def test_default_are_returned():
     assert (<Foo value1={123} value2="bar" />.props) == {'value1': 123, 'value2': 'bar', 'value3': 1}
     assert (<Foo value1={123} value2="bar" value3={2} />.props) == {'value1': 123, 'value2': 'bar', 'value3': 2}
     assert (<Foo value1={123} value2="bar" value3={2} value4="baz" />.props) == {'value1': 123, 'value2': 'bar', 'value3': 2, 'value4': 'baz'}
+
+def test_default_cannot_be_mandatory():
+    with pytest.raises(PyxlException):
+        class Foo(DummyBase):
+            class PropTypes:
+                value: Mandatory[str] = "foo"
+
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Mandatory[str] = NotProvided

--- a/tests/pyxl/test_default_props_values.py
+++ b/tests/pyxl/test_default_props_values.py
@@ -1,0 +1,49 @@
+# coding: mixt
+
+"""Ensure that complex proptypes are correctly validated."""
+
+import pytest
+from mixt.pyxl import html
+from mixt.pyxl.base import Base, PyxlException
+
+from typing import *
+
+
+class DummyBase(Base):
+    def _to_list(self, l):
+        pass
+
+
+def test_no_default_value():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: str
+
+    with pytest.raises(AttributeError):
+        <Foo />.value
+
+def test_valid_default_value_simple_type():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: str = "foo"
+
+    assert((<Foo />.value) == "foo")
+
+def test_invalid_default_value_simple_type():
+    with pytest.raises(PyxlException):
+        class Foo(DummyBase):
+            class PropTypes:
+                value: str = 123
+
+def test_valid_default_value_complex_type():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Union[int, float] = 123
+
+    assert (<Foo />.value) == 123
+
+def test_invalid_default_value_complex_type():
+    with pytest.raises(PyxlException):
+        class Foo(DummyBase):
+            class PropTypes:
+                value: Union[int, float] = "foo"

--- a/tests/pyxl/test_mandatory.py
+++ b/tests/pyxl/test_mandatory.py
@@ -1,0 +1,50 @@
+# coding: mixt
+
+"""Ensure that complex proptypes are correctly validated."""
+
+import pytest
+from mixt.pyxl import html
+from mixt.pyxl.base import Base, PyxlException, Mandatory
+
+from typing import *
+
+
+class DummyBase(Base):
+    def _to_list(self, l):
+        pass
+
+
+def test_prop_optional_by_default():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: str
+
+    (<Foo />)
+
+def test_prop_mandatory_ok_if_passed():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Mandatory[str]
+
+    (<Foo value="foo" />)
+
+def test_prop_mandatory_fail_if_not_passed():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Mandatory[str]
+
+    with pytest.raises(PyxlException):
+        <Foo />
+
+def test_complex_prop_mandatory():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Mandatory[Union[int, float]]
+
+    with pytest.raises(PyxlException):
+        <Foo />
+
+    with pytest.raises(PyxlException):
+        <Foo value="foo" />
+
+    (<Foo value={1} />)

--- a/tests/pyxl/test_mandatory.py
+++ b/tests/pyxl/test_mandatory.py
@@ -4,7 +4,7 @@
 
 import pytest
 from mixt.pyxl import html
-from mixt.pyxl.base import Base, PyxlException, Mandatory
+from mixt.pyxl.base import Base, PyxlException, Mandatory, NotProvided
 
 from typing import *
 
@@ -48,3 +48,13 @@ def test_complex_prop_mandatory():
         <Foo value="foo" />
 
     (<Foo value={1} />)
+
+def test_mandatory_prop_cannot_have_default():
+    with pytest.raises(PyxlException):
+        class Foo(DummyBase):
+            class PropTypes:
+                value: Mandatory[str] = "foo"
+
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Mandatory[str] = NotProvided

--- a/tests/pyxl/test_nospace_closing_tag.py
+++ b/tests/pyxl/test_nospace_closing_tag.py
@@ -6,27 +6,27 @@ from mixt.pyxl import html
 from mixt.pyxl.element import Element
 
 
-def test_normal_tag_without_attributes():
+def test_normal_tag_without_props():
     assert str(<button />) == '<button></button>'
     assert str(<button/>) == '<button></button>'
 
 
-def test_normal_tag_with_attributes():
+def test_normal_tag_with_props():
     assert str(<button name="foo" />) == '<button name="foo"></button>'
     assert str(<button name="foo"/>) == '<button name="foo"></button>'
 
 
-def test_nochild_tag_without_attributes():
+def test_nochild_tag_without_props():
     assert str(<link />) == '<link />'
     assert str(<link/>) == '<link />'
 
 
-def test_nochild_tag_with_attributes():
+def test_nochild_tag_with_props():
     assert str(<link rel="foo" />) == '<link rel="foo" />'
     assert str(<link rel="foo"/>) == '<link rel="foo" />'
 
 
-def test_new_element_without_attributes():
+def test_new_element_without_props():
     class Foo(Element):
 
         def render(self):
@@ -36,9 +36,9 @@ def test_new_element_without_attributes():
     assert str(<Foo/>) == '<div data-name="foo"></div>'
 
 
-def test_new_element_with_attributes():
+def test_new_element_with_props():
     class Foo(Element):
-        class Attrs:
+        class PropTypes:
             name: str
 
         def render(self):

--- a/tests/pyxl/test_nospace_closing_tag.py
+++ b/tests/pyxl/test_nospace_closing_tag.py
@@ -38,9 +38,8 @@ def test_new_element_without_attributes():
 
 def test_new_element_with_attributes():
     class Foo(Element):
-        __attrs__ = {
-            'name': str
-        }
+        class Attrs:
+            name: str
 
         def render(self):
             return <div data-name="{self.name}"/>


### PR DESCRIPTION
First, we want to go from the names "attributes" to "props" to be more "react-like"

Then, Instead of an `__attrs__` dict, we now use a class named `PropTypes`.

Attributes of this class are the props, each one MUST have a type defined (following python typing), and CAN have a value which then will be used as the default one.

Props are optional by default, but can be mandatory.

Everything is validated, using the `enforce` lib for complex types.