### PR TITLE
Add "dev mode" default to True. Validate props if True only.

### DIFF
--- a/tests/pyxl/test_attributes_as_kwargs.py
+++ b/tests/pyxl/test_attributes_as_kwargs.py
@@ -1,6 +1,7 @@
 # coding: mixt
 
 """Ensure we can pass attributes to tags as kwargs."""
+
 import pytest
 from mixt.pyxl import html
 from mixt.pyxl.codec.parser import ParseError

--- a/tests/pyxl/test_default_props_values.py
+++ b/tests/pyxl/test_default_props_values.py
@@ -1,6 +1,6 @@
 # coding: mixt
 
-"""Ensure that complex proptypes are correctly validated."""
+"""Ensure that proptypes default values are correctly used."""
 
 import pytest
 from mixt.pyxl import html

--- a/tests/pyxl/test_dev_mode.py
+++ b/tests/pyxl/test_dev_mode.py
@@ -1,0 +1,182 @@
+# coding: mixt
+
+"""Ensure that dev-mode can be toggled and does not validate data if off."""
+from typing import Union
+
+import pytest
+from mixt.pyxl.base import PropTypes, set_dev_mode, unset_dev_mode, override_dev_mode, in_dev_mode, Base, Choices, PyxlException
+
+
+class DummyBase(Base):
+    def _to_list(self, l):
+        pass
+
+
+def test_proptypes_default_dev_mode_is_true():
+    assert PropTypes.__in_dev_mode__()
+
+
+def test_proptypes_set_dev_mode_toggle():
+    assert PropTypes.__in_dev_mode__()
+    try:
+
+        PropTypes.__unset_dev_mode__()
+        assert not PropTypes.__in_dev_mode__()
+        PropTypes.__unset_dev_mode__()
+        assert not PropTypes.__in_dev_mode__()
+
+        PropTypes.__set_dev_mode__()
+        assert PropTypes.__in_dev_mode__()
+        PropTypes.__set_dev_mode__()
+        assert PropTypes.__in_dev_mode__()
+
+        PropTypes.__set_dev_mode__(False)
+        assert not PropTypes.__in_dev_mode__()
+        PropTypes.__set_dev_mode__(False)
+        assert not PropTypes.__in_dev_mode__()
+
+        PropTypes.__set_dev_mode__(True)
+        assert PropTypes.__in_dev_mode__()
+        PropTypes.__set_dev_mode__(True)
+        assert PropTypes.__in_dev_mode__()
+
+    finally:
+        PropTypes.__dev_mode__ = True  # force restore the normal state
+
+
+def test_proptypes_context_manager():
+    assert PropTypes.__in_dev_mode__()
+
+    try:
+        with PropTypes.__override_dev_mode__(False):
+            assert not PropTypes.__in_dev_mode__()
+        assert PropTypes.__in_dev_mode__()
+
+        PropTypes.__set_dev_mode__(False)
+
+        with PropTypes.__override_dev_mode__(False):
+            assert not PropTypes.__in_dev_mode__()
+        assert not PropTypes.__in_dev_mode__()
+
+        with PropTypes.__override_dev_mode__(True):
+            assert PropTypes.__in_dev_mode__()
+        assert not PropTypes.__in_dev_mode__()
+
+        PropTypes.__set_dev_mode__(True)
+
+        with PropTypes.__override_dev_mode__(True):
+            assert PropTypes.__in_dev_mode__()
+        assert PropTypes.__in_dev_mode__()
+
+    finally:
+        PropTypes.__dev_mode__ = True  # force restore the normal state
+
+
+def test_global_default_dev_mode_is_true():
+    assert in_dev_mode()
+
+
+def test_global_set_dev_mode_toggle():
+    assert in_dev_mode()
+    try:
+
+        unset_dev_mode()
+        assert not in_dev_mode()
+        unset_dev_mode()
+        assert not in_dev_mode()
+
+        set_dev_mode()
+        assert in_dev_mode()
+        set_dev_mode()
+        assert in_dev_mode()
+
+        set_dev_mode(False)
+        assert not in_dev_mode()
+        set_dev_mode(False)
+        assert not in_dev_mode()
+
+        set_dev_mode(True)
+        assert in_dev_mode()
+        set_dev_mode(True)
+        assert in_dev_mode()
+
+    finally:
+        PropTypes.__dev_mode__ = True  # force restore the normal state
+
+
+def test_global_context_manager():
+    assert in_dev_mode()
+
+    try:
+        with override_dev_mode(False):
+            assert not in_dev_mode()
+        assert in_dev_mode()
+
+        set_dev_mode(False)
+
+        with override_dev_mode(False):
+            assert not in_dev_mode()
+        assert not in_dev_mode()
+
+        with override_dev_mode(True):
+            assert in_dev_mode()
+        assert not in_dev_mode()
+
+        set_dev_mode(True)
+
+        with override_dev_mode(True):
+            assert in_dev_mode()
+        assert in_dev_mode()
+
+    finally:
+        PropTypes.__dev_mode__ = True  # force restore the normal state
+
+
+def test_choices_are_not_checked_in_non_dev_mode():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Choices = ['a', 'b']
+
+    with override_dev_mode(dev_mode=False):
+        assert (<Foo value='c' />.value) == 'c'
+
+    with pytest.raises(PyxlException):
+        <Foo value='c' />
+
+
+def test_boolean_is_not_validated_in_non_dev_mode():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: bool
+
+    with override_dev_mode(dev_mode=False):
+        # normal behavior still works
+        assert (<Foo value='value' />.value) is True
+        assert (<Foo value={False} />.value) is False
+        assert (<Foo value='false' />.value) is False
+        # but this only works in non-dev mode
+        assert (<Foo value='fake' />.value) is True
+        assert (<Foo value={0} />.value) is False
+
+    with pytest.raises(PyxlException):
+        <Foo value='fake' />
+
+    with pytest.raises(PyxlException):
+        <Foo value={0} />
+
+
+def test_normal_value_is_not_validated_in_non_dev_mode():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: int
+            complex: Union[int, float]
+
+    with override_dev_mode(dev_mode=False):
+        assert (<Foo value='foo' />.value) == 'foo'
+        assert (<Foo complex='bar' />.complex) == 'bar'
+
+    with pytest.raises(PyxlException):
+        <Foo value='foo' />
+
+    with pytest.raises(PyxlException):
+        <Foo complex='bar' />

--- a/tests/pyxl/test_mandatory.py
+++ b/tests/pyxl/test_mandatory.py
@@ -1,6 +1,6 @@
 # coding: mixt
 
-"""Ensure that complex proptypes are correctly validated."""
+"""Ensure that mandatory proptypes are correctly checked."""
 
 import pytest
 from mixt.pyxl import html


### PR DESCRIPTION
The aim is to speed up code in production, as does React with proptypes
that are only validated in "prod" env.