### PR TITLE
Make easier to pass numbers/bools/None/NotProvided

### DIFF
--- a/src/mixt/codec/parser.py
+++ b/src/mixt/codec/parser.py
@@ -133,6 +133,21 @@ class PyxlParser(HTMLTokenizer):
                         yield part
                     prev_was_python = False
 
+        def format_part(part):
+            """Allow numbers, bools, None and NotProvided to be passed without being stringified."""
+            if part in {'True', 'False', 'None', 'NotProvided'}:
+                return part
+            if part.isdecimal():
+                return part
+            try:
+                float(part)
+            except:
+                pass
+            else:
+                return part
+
+            return repr(part)
+
         output = []
 
         if attr_value is True:
@@ -145,7 +160,7 @@ class PyxlParser(HTMLTokenizer):
                 if type(part) == list:
                     output.append(Untokenizer().untokenize(part))
                 else:
-                    output.append(repr(part))
+                    output.append(format_part(part))
             else:
                 output.append('u"".join((')
                 for part in attr_value:
@@ -154,7 +169,7 @@ class PyxlParser(HTMLTokenizer):
                         output.append(Untokenizer().untokenize(part))
                         output.append(')')
                     else:
-                        output.append(repr(part))
+                        output.append(format_part(part))
                     output.append(', ')
                 output.append('))')
 

--- a/src/mixt/internal/proptypes.py
+++ b/src/mixt/internal/proptypes.py
@@ -337,11 +337,15 @@ class BasePropTypes:
             raise InvalidPropBoolError(cls.__owner_name__, name, value)
 
         # normal check
+        prop_type = cls.__type__(name)
+
+        # allow numbers to be passed without quotes
+        if prop_type is str and isinstance(value, (int, float)):
+            value = str(value)
 
         if not BasePropTypes.__dev_mode__:
             return value
 
-        prop_type = cls.__type__(name)
         try:
             if isinstance(value, prop_type):
                 return value

--- a/tests/test_complex_proptypes.py
+++ b/tests/test_complex_proptypes.py
@@ -2,6 +2,7 @@
 
 """Ensure that complex proptypes are correctly validated."""
 
+from typing import Union
 import pytest
 from mixt import html
 from mixt.internal.base import Base
@@ -24,18 +25,16 @@ def test_simple_union():
 
     assert (<Foo value={1} />.value) == 1
     assert (<Foo value={1.1} />.value) == 1.1
+    assert (<Foo value="1" />.value) == 1
+    assert (<Foo value="1.1" />.value) == 1.1
+    assert (<Foo value=1 />.value) == 1
+    assert (<Foo value=1.1 />.value) == 1.1
 
     with pytest.raises(InvalidPropValueError):
         <Foo value={"foo"} />
 
     with pytest.raises(InvalidPropValueError):
         <Foo value="foo" />
-
-    with pytest.raises(InvalidPropValueError):
-        <Foo value="1" />
-
-    with pytest.raises(InvalidPropValueError):
-        <Foo value=1 />
 
     with pytest.raises(InvalidPropValueError):
         <Foo value={None} />
@@ -121,3 +120,87 @@ def test_data_and_aria_are_not_validated():
     assert el.data_complex == {'foo': 123}
 
     assert str(el) == '<div data-string="foo" aria-number="123" data-complex="{\'foo\': 123}"></div>'
+
+
+def test_ints_can_be_passed_unquoted_for_string_props():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: str
+
+    assert (<Foo value=1 />.value) == '1'
+
+
+def test_floats_can_be_passed_unquoted_for_string_props():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: str
+
+    assert (<Foo value=1.1 />.value) == '1.1'
+
+
+def test_int_propss_can_be_passed_unquoted_():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: int
+
+    assert (<Foo value=1 />.value) == 1
+
+
+def test_float_props_can_be_passed_unquoted():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: float
+
+    assert (<Foo value=1.1 />.value) == 1.1
+
+
+def test_none_can_be_passed_unquoted():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Union[int, None]
+
+    assert (<Foo value=None />.value) is None
+
+
+def test_none_can_be_passed_quoted():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: Union[int, None]
+
+    assert (<Foo value="None" />.value) is None
+
+
+def test_bools_can_be_passed_unquoted():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: bool
+
+    assert (<Foo value=False />.value) is False
+    assert (<Foo value=True />.value) is True
+
+
+def test_bools_can_be_passed_quoted():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: bool
+
+    assert (<Foo value="False" />.value) is False
+    assert (<Foo value="True" />.value) is True
+
+
+def test_notprovided_can_be_passed_unquoted():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: str
+
+    with pytest.raises(UnsetPropError):
+        <Foo value=NotProvided />.value
+
+
+def test_notprovided_can_be_passed_quoted():
+    class Foo(DummyBase):
+        class PropTypes:
+            value: str
+
+    with pytest.raises(UnsetPropError):
+        <Foo value="NotProvided" />.value

--- a/tests/test_default_props_values.py
+++ b/tests/test_default_props_values.py
@@ -35,7 +35,7 @@ def test_invalid_default_value_simple_type():
     with pytest.raises(InvalidPropValueError):
         class Foo(DummyBase):
             class PropTypes:
-                value: str = 123
+                value: str = {1, 2, 3}
 
 def test_valid_default_value_complex_type():
     class Foo(DummyBase):


### PR DESCRIPTION
For these, it's not needed anymore to pass them in python via {}