### PR TITLE
Add css and js collectors to collect css/js and deport it

### DIFF
--- a/src/mixt/__init__.py
+++ b/src/mixt/__init__.py
@@ -4,6 +4,6 @@
 from .element import Element  # noqa: F401
 from . import exceptions  # noqa: F401
 from .internal.base import BaseContext, EmptyContext  # noqa: F401
-from .internal.collector import Collector, CSSCollector  # noqa: F401
+from .internal.collector import Collector, CSSCollector, JSCollector  # noqa: F401
 from .internal.dev_mode import *  # noqa: F401,F403  # pylint: disable=wildcard-import
 from .proptypes import *  # noqa: F401,F403  # pylint: disable=wildcard-import

--- a/src/mixt/__init__.py
+++ b/src/mixt/__init__.py
@@ -4,5 +4,6 @@
 from .element import Element  # noqa: F401
 from . import exceptions  # noqa: F401
 from .internal.base import BaseContext, EmptyContext  # noqa: F401
+from .internal.collector import Collector, CSSCollector  # noqa: F401
 from .internal.dev_mode import *  # noqa: F401,F403  # pylint: disable=wildcard-import
 from .proptypes import *  # noqa: F401,F403  # pylint: disable=wildcard-import

--- a/src/mixt/element.py
+++ b/src/mixt/element.py
@@ -130,7 +130,9 @@ class Element(WithClass):
 
             self.prerender(context)
 
-            element: OneOrManyElements = self.render(self.context or EmptyContext)
+            element: Optional[OneOrManyElements] = self.render(
+                self.context or EmptyContext
+            )
 
             if isinstance(element, (list, tuple)):
                 element = Fragment()(element)  # type: ignore
@@ -155,8 +157,8 @@ class Element(WithClass):
 
         return self._element  # type: ignore
 
-    def render(self, context: OptionalContext) -> OneOrManyElements:
-        """Return element to be rendered as html.
+    def render(self, context: OptionalContext) -> Optional[OneOrManyElements]:
+        """Return elements to be rendered as html.
 
         Must be implemented in subclasses.
 
@@ -164,6 +166,11 @@ class Element(WithClass):
         ----------
         context: OptionalContext
             The context passed through the tree.
+
+        Returns
+        -------
+        Optional[OneOrManyElements]
+            None, or one or many elements or strings.
 
         """
         raise NotImplementedError()

--- a/src/mixt/element.py
+++ b/src/mixt/element.py
@@ -138,11 +138,20 @@ class Element(WithClass):
             self._element = element  # type: ignore
 
             if isinstance(self._element, Base):
+                self._element._attach_to_parent(self)
                 self._element._set_context(
                     self.context  # pass None if context not defined, not EmptyContext
                 )
 
             self.postrender(self._element, context)  # type: ignore
+
+            parent = self.__parent__
+            while parent:
+                if isinstance(parent, Element):
+                    parent.postrender_child_element(  # type: ignore
+                        self, self._element, context
+                    )
+                parent = parent.__parent__
 
         return self._element  # type: ignore
 
@@ -154,7 +163,7 @@ class Element(WithClass):
         Parameters
         ----------
         context: OptionalContext
-            The context passed through the tree
+            The context passed through the tree.
 
         """
         raise NotImplementedError()
@@ -167,7 +176,7 @@ class Element(WithClass):
         Parameters
         ----------
         context: OptionalContext
-            The context passed through the tree
+            The context passed through the tree.
 
         """
         pass
@@ -179,10 +188,29 @@ class Element(WithClass):
 
         Parameters
         ----------
-        element: Base
+        element: AnElement
             The element rendered by ``render``. Could be an Element, an html tag, a RawHtml...
         context: OptionalContext
-            The context passed through the tree
+            The context passed through the tree.
+
+        """
+        pass
+
+    def postrender_child_element(
+        self, child: "Element", child_element: AnElement, context: OptionalContext
+    ) -> None:
+        """Provide a hook for every parent to do things after any child is rendered.
+
+        Default behavior is to do nothing.
+
+        Parameters
+        ----------
+        child: Element
+            The element in a tree on which ``render`` was just called.
+        child_element: AnElement
+            The element rendered by the call of the ``render`` method of `child`.
+        context: OptionalContext
+            The context passed through the tree.
 
         """
         pass

--- a/src/mixt/internal/base.py
+++ b/src/mixt/internal/base.py
@@ -847,6 +847,43 @@ class WithClass(Base):
         )
 
 
+class Fragment(WithClass):
+    """An invisible tag that is used to hold many others."""
+
+    class PropTypes:
+        id: str
+
+    def _to_list(self, acc: List) -> None:
+        """Add the children parts to the list `acc`.
+
+        Parameters
+        ----------
+        acc: List
+            The accumulator list where to append the parts.
+
+        """
+        self._render_children_to_list(acc)
+
+    def get_id(self) -> str:
+        """Return the ``id`` prop of the element."""
+        return self.prop("id")
+
+    def _attach_to_parent(self, parent: "Base") -> None:
+        """Save the given `parent` as the parent of the children of the fragment.
+
+        Parameters
+        ----------
+        parent: Base
+            The element that will be saved as the parent of children of the fragment.
+
+        """
+        super()._attach_to_parent(parent)
+
+        for child in self.__children__:
+            if isinstance(child, Base):
+                child._attach_to_parent(parent)
+
+
 class BaseContext(Base):
     """A special element used in ``Base`` to propagate its props down the tree.
 

--- a/src/mixt/internal/base.py
+++ b/src/mixt/internal/base.py
@@ -276,6 +276,7 @@ class Base(object, metaclass=BaseMetaclass):
             This can be a single child, or a list of children,
             each one possibly being also a list, etc...
             Every children that is ``None`` or ``False`` is ignored.
+            A fragment is converted to a list of its children.
 
         Returns
         -------
@@ -283,6 +284,9 @@ class Base(object, metaclass=BaseMetaclass):
             The flattened list of children.
 
         """
+        if isinstance(child_or_children, Fragment):
+            child_or_children = child_or_children.__children__
+
         if isinstance(child_or_children, (list, tuple)):
             children = list(
                 chain.from_iterable(

--- a/src/mixt/internal/base.py
+++ b/src/mixt/internal/base.py
@@ -327,6 +327,25 @@ class Base(object, metaclass=BaseMetaclass):
         self._attach_children(children)
         self.__children__[0:0] = children
 
+    def remove(self, child_or_children: OneOrManyElements) -> None:
+        """Remove some children from the current element.
+
+        Parameters
+        ----------
+        child_or_children: OneOrManyElements
+            The child(ren) to remove.
+
+        """
+        children_to_remove = self._child_to_children(child_or_children)
+        new_children = []
+        for child in self.__children__:
+            if child in children_to_remove:
+                if isinstance(child, Base):
+                    child.__parent__ = None
+                continue
+            new_children.append(child)
+        self.__children__[:] = new_children
+
     def __getattr__(self, name: str) -> Any:
         """Return a prop defined by `name`, if it is defined.
 

--- a/src/mixt/internal/collector.py
+++ b/src/mixt/internal/collector.py
@@ -146,7 +146,12 @@ class Collector(Element, metaclass=CollectorMetaclass):
 
 
 class CSSCollector(Collector):
-    """A collector that will surround collected content in a <style> tag in ``render_collected``."""
+    """A collector that will surround collected content in a <style> tag in ``render_collected``.
+
+    It can collect via the ``<CSSCollector.Collect>`` tag, and/or via the ``render_css`` method
+    on the child.
+
+    """
 
     class PropTypes:
         type: str = "text/css"
@@ -162,9 +167,26 @@ class CSSCollector(Collector):
 
         return Style(type=self.type)(str_collected)
 
+    def postrender_child_element(
+        self, child: "Element", child_element: AnElement, context: OptionalContext
+    ) -> None:
+        """Catch ``child.render_css`` output in addition to ``Collect`` elements.
+
+        For the parameters, see ``Collector.postrender_child_element``.
+
+        """
+        if hasattr(child, "render_css") and callable(child.render_css):
+            self.__collected__.append(child.render_css(context))
+        super().postrender_child_element(child, child_element, context)
+
 
 class JSCollector(Collector):
-    """Collector that will surround collected content in a <script> tag in ``render_collected``."""
+    """A collector that will surround collected content in a <script> tag in ``render_collected``.
+
+    It can collect via the ``<JSCollector.Collect>`` tag, and/or via the ``render_js`` method
+    on the child.
+
+    """
 
     class PropTypes:
         type: str = "text/javascript"
@@ -179,3 +201,15 @@ class JSCollector(Collector):
         str_collected: str = cast(str, super().render_collected())
 
         return Script(type=self.type)(str_collected)
+
+    def postrender_child_element(
+        self, child: "Element", child_element: AnElement, context: OptionalContext
+    ) -> None:
+        """Catch ``child.render_js`` output in addition to ``Collect`` elements.
+
+        For the parameters, see ``Collector.postrender_child_element``.
+
+        """
+        if hasattr(child, "render_js") and callable(child.render_js):
+            self.__collected__.append(child.render_js(context))
+        super().postrender_child_element(child, child_element, context)

--- a/src/mixt/internal/collector.py
+++ b/src/mixt/internal/collector.py
@@ -1,0 +1,163 @@
+"""Provide the ``Element`` class to create reusable components."""
+
+
+from typing import cast, Any, Dict, List, Sequence
+
+from ..element import Element
+from ..html import Style
+from ..proptypes import DefaultChoices
+from .base import AnElement, Base, BaseMetaclass, OneOrManyElements, OptionalContext
+
+
+class CollectorMetaclass(BaseMetaclass):
+    """A metaclass for collector classes."""
+
+    def __init__(
+        cls, name: str, parents: Sequence[type], attrs: Dict[str, Any]  # noqa: B902
+    ) -> None:
+        """Construct the class, and create a ``Collect`` inside class if not given in `attrs`.
+
+        Parameters
+        ----------
+        name: str
+            The name of the class to construct.
+        parents: Sequence[type]
+            A tuple with the direct parent classes of the class to construct.
+        attrs: Dict[str, Any]
+            Dict with the attributes defined in the class.
+
+        """
+        super().__init__(name, parents, attrs)
+        if not attrs.get("Collect"):
+
+            class Collect(Element):
+                """Element that renders nothing."""
+
+                def render(self, context: OptionalContext) -> None:
+                    """Return nothing, the collector will render if needed.
+
+                    Parameters
+                    ----------
+                    context: OptionalContext
+                        The context passed through the tree.
+
+                    """
+                    pass
+
+            cls.Collect = Collect
+
+
+class Collector(Element, metaclass=CollectorMetaclass):
+    """Base of all collectors. Render children and collect ones of its own Collect class."""
+
+    class PropTypes:
+        render_position: DefaultChoices = cast(
+            DefaultChoices, [None, "before", "after"]
+        )
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Create the collector with an empty list of collected children..
+
+        ``__collected`` will contain all children of collected children.
+
+        Parameters
+        ----------
+        kwargs : Dict[str, Any]
+            The props to set on this collector.
+
+        """
+        self.__collected__: List[AnElement] = []
+        super().__init__(**kwargs)
+
+    def render(self, context: OptionalContext) -> OneOrManyElements:
+        """Return the children of a collector, to be rendered as html.
+
+        Parameters
+        ----------
+        context: OptionalContext
+            The context passed through the tree.
+
+        Returns
+        -------
+        Optional[OneOrManyElements]
+            None, or one or many elements or strings.
+
+        """
+        return self.children()
+
+    def postrender_child_element(
+        self, child: "Element", child_element: AnElement, context: OptionalContext
+    ) -> None:
+        """Catch all children being instance of the ``Collect`` class when rendered.
+
+        Parameters
+        ----------
+        child: Element
+            The element in a tree on which ``render`` was just called.
+        child_element: AnElement
+            The element rendered by the call of the ``render`` method of `child`.
+        context: OptionalContext
+            The context passed through the tree.
+
+        """
+        if isinstance(child, self.Collect):
+            self.__collected__.append(child)
+
+    def render_collected(self) -> OneOrManyElements:
+        """Render the content of all collected children at once.
+
+        It's done as if all the children of the collected ``Collect`` instances
+        were in the same ``Fragment``.
+
+        Returns
+        -------
+        str
+            All collected content stringified and concatened.
+
+        """
+        str_list: List[AnElement] = []
+
+        for collected in self.__collected__:
+            if isinstance(collected, Base):
+                for child in collected.__children__:
+                    self._render_element_to_list(child, str_list)
+            else:
+                self._render_element_to_list(collected, str_list)
+
+        return self._str_list_to_string(str_list)
+
+    def to_list(self, acc: List) -> None:
+        """Fill the list `acc` with strings that will be concatenated to produce the html string.
+
+        Simply prepend/append ``self.render_collected`` as a callable depening on the
+        ``render_position`` prop.
+
+        Parameters
+        ----------
+        acc: List
+            The accumulator list where to append the parts.
+
+        """
+        if self.render_position == "before":
+            acc.append(self.render_collected)
+        super()._to_list(acc)
+        if self.render_position == "after":
+            acc.append(self.render_collected)
+
+
+class CSSCollector(Collector):
+    """A collector that will surround collected content in a <style> tag in ``render_collected``."""
+
+    class PropTypes:
+        type: str = "text/css"
+
+    def render_collected(self) -> OneOrManyElements:
+        """Render the content of all collected children at once.
+
+        Simply put the result of the normal call to ``render_collected`` into a
+        ``<style>`` tag.
+
+        """
+        str_collected: str = cast(str, super().render_collected())
+
+        return Style(type=self.type)(str_collected)

--- a/src/mixt/internal/collector.py
+++ b/src/mixt/internal/collector.py
@@ -4,7 +4,7 @@
 from typing import cast, Any, Dict, List, Sequence
 
 from ..element import Element
-from ..html import Style
+from ..html import Script, Style
 from ..proptypes import DefaultChoices
 from .base import AnElement, Base, BaseMetaclass, OneOrManyElements, OptionalContext
 
@@ -161,3 +161,21 @@ class CSSCollector(Collector):
         str_collected: str = cast(str, super().render_collected())
 
         return Style(type=self.type)(str_collected)
+
+
+class JSCollector(Collector):
+    """Collector that will surround collected content in a <script> tag in ``render_collected``."""
+
+    class PropTypes:
+        type: str = "text/javascript"
+
+    def render_collected(self) -> OneOrManyElements:
+        """Render the content of all collected children at once.
+
+        Simply put the result of the normal call to ``render_collected`` into a
+        ``<script>`` tag.
+
+        """
+        str_collected: str = cast(str, super().render_collected())
+
+        return Script(type=self.type)(str_collected)

--- a/src/mixt/internal/html.py
+++ b/src/mixt/internal/html.py
@@ -4,7 +4,14 @@ from typing import Any, Dict, List, Optional, Sequence, cast
 
 from ..exceptions import InvalidChildrenError
 from ..proptypes import Choices, NotProvided
-from .base import Base, BaseMetaclass, OneOrManyElements, WithClass, escape
+from .base import (  # noqa: F401  # pylint: disable=unused-import
+    Base,
+    BaseMetaclass,
+    Fragment,  # imported to be used in html like ``<Fragment>``, so  ``html.Fragment``
+    OneOrManyElements,
+    WithClass,
+    escape,
+)
 from .proptypes import BasePropTypes
 
 
@@ -257,43 +264,6 @@ def Raw(text: str) -> RawHtml:  # pylint: disable=invalid-name
 
     """
     return RawHtml(text=text)  # type: ignore
-
-
-class Fragment(WithClass):
-    """An invisible tag that is used to hold many others."""
-
-    class PropTypes:
-        id: str
-
-    def _to_list(self, acc: List) -> None:
-        """Add the children parts to the list `acc`.
-
-        Parameters
-        ----------
-        acc: List
-            The accumulator list where to append the parts.
-
-        """
-        self._render_children_to_list(acc)
-
-    def get_id(self) -> str:
-        """Return the ``id`` prop of the element."""
-        return self.prop("id")
-
-    def _attach_to_parent(self, parent: "Base") -> None:
-        """Save the given `parent` as the parent of the children of the fragment.
-
-        Parameters
-        ----------
-        parent: Base
-            The element that will be saved as the parent of children of the fragment.
-
-        """
-        super()._attach_to_parent(parent)
-
-        for child in self.__children__:
-            if isinstance(child, Base):
-                child._attach_to_parent(parent)
 
 
 class Comment(Base):

--- a/src/mixt/internal/html.py
+++ b/src/mixt/internal/html.py
@@ -280,6 +280,21 @@ class Fragment(WithClass):
         """Return the ``id`` prop of the element."""
         return self.prop("id")
 
+    def _attach_to_parent(self, parent: "Base") -> None:
+        """Save the given `parent` as the parent of the children of the fragment.
+
+        Parameters
+        ----------
+        parent: Base
+            The element that will be saved as the parent of children of the fragment.
+
+        """
+        super()._attach_to_parent(parent)
+
+        for child in self.__children__:
+            if isinstance(child, Base):
+                child._attach_to_parent(parent)
+
 
 class Comment(Base):
     """Implement HTML comments. Will not set them in final HTML."""

--- a/tests/pyxl_original/test_basic.py
+++ b/tests/pyxl_original/test_basic.py
@@ -271,3 +271,20 @@ def test_doctype():
 def test_cdata():
     assert str(<div><![CDATA[Testing Data here]]></div>) == '<div><![CDATA[Testing Data here]]></div>'
     assert str(<div><CData cdata="Testing Data here"/></div>) == '<div><![CDATA[Testing Data here]]></div>'
+
+
+def test_callable_to_string():
+
+    class Foo(Base):
+
+        def render_qux(self):
+            return "qux"
+
+        def _to_list(self, acc):
+            self._render_children_to_list(acc)
+            acc.append(self.render_qux)
+
+    def render_bar():
+        return 'bar'
+
+    assert str(<Foo>foo{render_bar}baz</Foo>) == "foobarbazqux"

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -94,3 +94,26 @@ def test_css_collector():
 <style type="text/css">
 .content { margin: 15px; }
 </style>"""
+
+    class App(Element):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.css_ref = self.add_ref()
+
+        def render(self, context):
+            return \
+                <html>
+                    <head>
+                    {lambda: self.css_ref.current.render_collected()}
+                    </head>
+                    <body>
+                        <CSSCollector ref={self.css_ref}>
+                            <Content><p>Hello</p></Content>
+                        </CSSCollector>
+                    </body>
+                </html>
+
+    assert str(<App />) == """\
+<html><head><style type="text/css">
+.content { margin: 15px; }
+</style></head><body><div class="content"><p>Hello</p></div></body></html>"""

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,0 +1,96 @@
+# coding: mixt
+
+"""Ensure that parents are saved correctly."""
+
+from mixt import Element, html
+from mixt.internal.collector import Collector, CSSCollector
+
+
+def test_collector():
+
+    class Child(Element):
+        def render(self, context):
+            return [
+                <Collector.Collect>
+                    CHILD
+                </Collector.Collect>,
+                self.children(),
+                <div>child-div</div>,
+            ]
+
+    class Parent(Element):
+        def render(self, context):
+            return [
+                <Collector.Collect>
+                    PARENT
+                    <div />
+                </Collector.Collect>,
+                self.children(),
+                <Child><div>parent-child-children</div></Child>,
+                <div>parent-div</div>,
+            ]
+
+    collector = <Collector>
+        <Parent>
+            <Child><div>child-children</div></Child>
+            <div>parent-children</div>
+        </Parent>
+        <Collector.Collect>{"""
+            MAIN
+            MAIN
+        """}</Collector.Collect>
+        <Child><div>child-children</div></Child>
+    </Collector>
+
+    str_collector = str(collector)
+    assert 'CHILD' not in str_collector
+    assert 'PARENT' not in str_collector
+    assert 'MAIN' not in str_collector
+
+
+    assert len(collector.__collected__) == 5
+
+    assert len(collector.__collected__[0].__children__) == 2
+    assert collector.__collected__[0].__children__[0].prop("text") == "PARENT"
+    assert isinstance(collector.__collected__[0].__children__[1], html.Div)
+
+    for index, text in [(1, "CHILD"), (2, "CHILD"), (4, "CHILD")]:
+        assert len(collector.__collected__[index].__children__) == 1
+        assert collector.__collected__[index].__children__[0].prop("text") == text
+
+    assert len(collector.__collected__[3].__children__) == 1
+    assert collector.__collected__[3].__children__[0] == """
+            MAIN
+            MAIN
+        """
+
+    assert collector.render_collected() == """\
+PARENT<div></div>CHILDCHILD
+            MAIN
+            MAIN
+        CHILD"""
+
+
+def test_css_collector():
+
+    class Content(Element):
+
+        def render_css(self, context):
+            return <CSSCollector.Collect>{"""
+.content { margin: 15px; }
+"""}
+            </CSSCollector.Collect>
+
+        def render(self, context):
+            return <Fragment>
+                {self.render_css(context)}
+                <div class="content">{self.children()}</div>
+            </Fragment>
+
+    collector = <CSSCollector><Content><p>Hello</p></Content></CSSCollector>
+    str(collector)
+
+    assert str(collector.render_collected()) == """\
+<style type="text/css">
+.content { margin: 15px; }
+</style>"""

--- a/tests/test_parent.py
+++ b/tests/test_parent.py
@@ -29,9 +29,7 @@ def test_parent_via_fragment():
     </div>
 
     assert div.__parent__ is None
-    frag, = div.__children__
-    assert frag.__parent__ is div
-    span1, span2 = frag.__children__
+    span1, span2 = div.__children__
     assert span1.__parent__ is div
     assert span2.__parent__ is div
     br, = span1.__children__
@@ -52,13 +50,7 @@ def test_parent_via_encapsulated_fragments():
     </div>
 
     assert div.__parent__ is None
-    frag1, = div.__children__
-    assert frag1.__parent__ is div
-    frag2, = frag1.__children__
-    assert frag2.__parent__ is div
-    frag3, = frag2.__children__
-    assert frag3.__parent__ is div
-    span1, span2 = frag3.__children__
+    span1, span2 = div.__children__
     assert span1.__parent__ is div
     assert span2.__parent__ is div
     br, = span1.__children__
@@ -80,16 +72,10 @@ def test_parent_via_encapsulated_fragments_and_siblings():
     </div>
 
     assert div.__parent__ is None
-    frag1, = div.__children__
-    assert frag1.__parent__ is div
-    frag2, = frag1.__children__
-    assert frag2.__parent__ is div
-    frag3, div2 = frag2.__children__
-    assert frag3.__parent__ is div
-    assert div2.__parent__ is div
-    span1, span2 = frag3.__children__
+    span1, span2, div2 = div.__children__
     assert span1.__parent__ is div
     assert span2.__parent__ is div
+    assert div2.__parent__ is div
     br, = span1.__children__
     assert br.__parent__ is span1
     assert len(span2.__children__) == 0

--- a/tests/test_parent.py
+++ b/tests/test_parent.py
@@ -138,6 +138,27 @@ def test_prepend_one_string_to_empty():
     assert str(parent) == '<div>foo</div>'
 
 
+def test_remove_one_el_from_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child = <span />
+    parent.remove(child)
+    assert parent.__children__ == []
+    assert parent_children is parent.__children__
+    assert child.__parent__ is None
+    assert str(parent) == '<div></div>'
+
+
+def test_remove_one_string_from_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child = "foo"
+    parent.remove(child)
+    assert parent.__children__ == []
+    assert parent_children is parent.__children__
+    assert str(parent) == '<div></div>'
+
+
 def test_append_many_to_empty():
     parent = <div />
     parent_children = parent.__children__
@@ -160,6 +181,18 @@ def test_prepend_many_to_empty():
     assert parent_children is parent.__children__
     assert child1.__parent__ is parent
     assert str(parent) == '<div><span></span>foo</div>'
+
+
+def test_remove_many_from_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    parent.remove([child1, child2])
+    assert parent.__children__ == []
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is None
+    assert str(parent) == '<div></div>'
 
 
 def test_append_many_levels_list_to_empty():
@@ -188,6 +221,19 @@ def test_prepend_many_levels_list_to_empty():
     assert child1.__parent__ is parent
     assert child3.__parent__ is parent
     assert str(parent) == '<div><span></span>foo<br /></div>'
+
+
+def test_remove_many_levels_list_from_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    child3 = <br />
+    parent.remove([child1, [child2, child3]])
+    assert parent.__children__ == []
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is None
+    assert str(parent) == '<div></div>'
 
 
 def test_append_one_el_to_non_empty():
@@ -235,6 +281,85 @@ def test_prepend_one_string_to_non_empty():
     assert parent.__children__ == [child, first_child]
     assert parent_children is parent.__children__
     assert str(parent) == '<div>foo<div></div></div>'
+
+
+def test_remove_one_absent_el_from_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child = <span />
+    assert parent.__children__ == [first_child]
+    parent.remove(child)
+    assert parent.__children__ == [first_child]
+    assert parent_children is parent.__children__
+    assert child.__parent__ is None
+    assert str(parent) == '<div><div></div></div>'
+
+
+def test_remove_one_absent_string_from_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child = "foo"
+    assert parent.__children__ == [first_child]
+    parent.remove(child)
+    assert parent.__children__ == [first_child]
+    assert parent_children is parent.__children__
+    assert str(parent) == '<div><div></div></div>'
+
+
+def test_remove_only_present_el_from_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    assert first_child.__parent__ is parent
+    parent_children = parent.__children__
+    assert parent.__children__ == [first_child]
+    parent.remove(first_child)
+    assert parent.__children__ == []
+    assert parent_children is parent.__children__
+    assert first_child.__parent__ is None
+    assert str(parent) == '<div></div>'
+
+
+def test_remove_only_present_string_from_non_empty():
+    first_child = "foo"
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    assert parent.__children__ == [first_child]
+    parent.remove(first_child)
+    assert parent.__children__ == []
+    assert parent_children is parent.__children__
+    assert str(parent) == '<div></div>'
+
+
+def test_remove_one_present_el_from_non_empty():
+    first_child = <div />
+    second_child = <span />
+    parent = <div>{first_child}{second_child}</div>
+    assert first_child.__parent__ is parent
+    assert second_child.__parent__ is parent
+    parent_children = parent.__children__
+    assert parent.__children__ == [first_child, second_child]
+    parent.remove(first_child)
+    assert parent.__children__ == [second_child]
+    assert parent_children is parent.__children__
+    assert first_child.__parent__ is None
+    assert second_child.__parent__ is parent
+    assert str(parent) == '<div><span></span></div>'
+
+
+def test_remove_one_present_string_from_non_empty():
+    first_child = "foo"
+    second_child = <span />
+    parent = <div>{first_child}{second_child}</div>
+    assert second_child.__parent__ is parent
+    parent_children = parent.__children__
+    assert parent.__children__ == [first_child, second_child]
+    parent.remove(first_child)
+    assert parent.__children__ == [second_child]
+    assert parent_children is parent.__children__
+    assert second_child.__parent__ is parent
+    assert str(parent) == '<div><span></span></div>'
 
 
 def test_append_many_to_non_empty():
@@ -291,3 +416,22 @@ def test_prepend_many_levels_list_to_non_empty():
     assert child1.__parent__ is parent
     assert child3.__parent__ is parent
     assert str(parent) == '<div><span></span>foo<br /><div></div></div>'
+
+
+def test_remove_many_levels_list_from_non_empty():
+    first_child = <div />
+    second_child = <span />
+    third_child = "foo"
+    parent = <div>{first_child}{second_child}{third_child}</div>
+    assert parent.__children__ == [first_child, second_child, third_child]
+    parent_children = parent.__children__
+    child1 = first_child
+    child2 = "bar"
+    child3 = <span/>
+    child4 = "foo"
+    parent.remove([child1, [child2, child3, [child4]]])
+    assert parent.__children__ == [second_child]
+    assert first_child.__parent__ is None
+    assert second_child.__parent__ is parent
+    assert parent_children is parent.__children__
+    assert str(parent) == '<div><span></span></div>'

--- a/tests/test_parent.py
+++ b/tests/test_parent.py
@@ -93,3 +93,201 @@ def test_parent_via_encapsulated_fragments_and_siblings():
     br, = span1.__children__
     assert br.__parent__ is span1
     assert len(span2.__children__) == 0
+
+
+def test_append_one_el_to_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child = <span />
+    assert parent.__children__ == []
+    parent.append(child)
+    assert parent.__children__ == [child]
+    assert parent_children is parent.__children__
+    assert child.__parent__ is parent
+    assert str(parent) == '<div><span></span></div>'
+
+
+def test_append_one_string_to_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child = "foo"
+    parent.append(child)
+    assert parent.__children__ == [child]
+    assert parent_children is parent.__children__
+    assert str(parent) == '<div>foo</div>'
+
+
+def test_prepend_one_el_to_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child = <span />
+    parent.prepend(child)
+    assert parent.__children__ == [child]
+    assert parent_children is parent.__children__
+    assert child.__parent__ is parent
+    assert str(parent) == '<div><span></span></div>'
+
+
+def test_prepend_one_string_to_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child = "foo"
+    parent.prepend(child)
+    assert parent.__children__ == [child]
+    assert parent_children is parent.__children__
+    assert str(parent) == '<div>foo</div>'
+
+
+def test_append_many_to_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    parent.append([child1, child2])
+    assert parent.__children__ == [child1, child2]
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is parent
+    assert str(parent) == '<div><span></span>foo</div>'
+
+
+def test_prepend_many_to_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    parent.prepend([child1, child2])
+    assert parent.__children__ == [child1, child2]
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is parent
+    assert str(parent) == '<div><span></span>foo</div>'
+
+
+def test_append_many_levels_list_to_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    child3 = <br />
+    parent.append([child1, [child2, child3]])
+    assert parent.__children__ == [child1, child2, child3]
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is parent
+    assert child3.__parent__ is parent
+    assert str(parent) == '<div><span></span>foo<br /></div>'
+
+
+def test_prepend_many_levels_list_to_empty():
+    parent = <div />
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    child3 = <br />
+    parent.prepend([child1, [child2, child3]])
+    assert parent.__children__ == [child1, child2, child3]
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is parent
+    assert child3.__parent__ is parent
+    assert str(parent) == '<div><span></span>foo<br /></div>'
+
+
+def test_append_one_el_to_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child = <span />
+    assert parent.__children__ == [first_child]
+    parent.append(child)
+    assert parent.__children__ == [first_child, child]
+    assert parent_children is parent.__children__
+    assert child.__parent__ is parent
+    assert str(parent) == '<div><div></div><span></span></div>'
+
+
+def test_append_one_string_to_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child = "foo"
+    parent.append(child)
+    assert parent.__children__ == [first_child, child]
+    assert parent_children is parent.__children__
+    assert str(parent) == '<div><div></div>foo</div>'
+
+
+def test_prepend_one_el_to_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child = <span />
+    parent.prepend(child)
+    assert parent.__children__ == [child, first_child]
+    assert parent_children is parent.__children__
+    assert child.__parent__ is parent
+    assert str(parent) == '<div><span></span><div></div></div>'
+
+
+def test_prepend_one_string_to_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child = "foo"
+    parent.prepend(child)
+    assert parent.__children__ == [child, first_child]
+    assert parent_children is parent.__children__
+    assert str(parent) == '<div>foo<div></div></div>'
+
+
+def test_append_many_to_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    parent.append([child1, child2])
+    assert parent.__children__ == [first_child, child1, child2]
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is parent
+    assert str(parent) == '<div><div></div><span></span>foo</div>'
+
+
+def test_prepend_many_to_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    parent.prepend([child1, child2])
+    assert parent.__children__ == [child1, child2, first_child]
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is parent
+    assert str(parent) == '<div><span></span>foo<div></div></div>'
+
+
+def test_append_many_levels_list_to_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    child3 = <br />
+    parent.append([child1, [child2, child3]])
+    assert parent.__children__ == [first_child, child1, child2, child3]
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is parent
+    assert child3.__parent__ is parent
+    assert str(parent) == '<div><div></div><span></span>foo<br /></div>'
+
+
+def test_prepend_many_levels_list_to_non_empty():
+    first_child = <div />
+    parent = <div>{first_child}</div>
+    parent_children = parent.__children__
+    child1 = <span />
+    child2 = "foo"
+    child3 = <br />
+    parent.prepend([child1, [child2, child3]])
+    assert parent.__children__ == [child1, child2, child3, first_child]
+    assert parent_children is parent.__children__
+    assert child1.__parent__ is parent
+    assert child3.__parent__ is parent
+    assert str(parent) == '<div><span></span>foo<br /><div></div></div>'

--- a/tests/test_parent.py
+++ b/tests/test_parent.py
@@ -1,0 +1,95 @@
+# coding: mixt
+
+"""Ensure that parents are saved correctly."""
+
+from mixt import html
+
+
+def test_simple_parent():
+    div = <div>
+        <span><br /></span>
+        <span />
+    </div>
+
+    assert div.__parent__ is None
+    span1, span2 = div.__children__
+    assert span1.__parent__ is div
+    assert span2.__parent__ is div
+    br, = span1.__children__
+    assert br.__parent__ is span1
+    assert len(span2.__children__) == 0
+
+
+def test_parent_via_fragment():
+    div = <div>
+        <Fragment>
+            <span><br /></span>
+            <span />
+        </Fragment>
+    </div>
+
+    assert div.__parent__ is None
+    frag, = div.__children__
+    assert frag.__parent__ is div
+    span1, span2 = frag.__children__
+    assert span1.__parent__ is div
+    assert span2.__parent__ is div
+    br, = span1.__children__
+    assert br.__parent__ is span1
+    assert len(span2.__children__) == 0
+
+
+def test_parent_via_encapsulated_fragments():
+    div = <div>
+        <Fragment>
+            <Fragment>
+                <Fragment>
+                    <span><br /></span>
+                    <span />
+                </Fragment>
+            </Fragment>
+        </Fragment>
+    </div>
+
+    assert div.__parent__ is None
+    frag1, = div.__children__
+    assert frag1.__parent__ is div
+    frag2, = frag1.__children__
+    assert frag2.__parent__ is div
+    frag3, = frag2.__children__
+    assert frag3.__parent__ is div
+    span1, span2 = frag3.__children__
+    assert span1.__parent__ is div
+    assert span2.__parent__ is div
+    br, = span1.__children__
+    assert br.__parent__ is span1
+    assert len(span2.__children__) == 0
+
+
+def test_parent_via_encapsulated_fragments_and_siblings():
+    div = <div>
+        <Fragment>
+            <Fragment>
+                <Fragment>
+                    <span><br /></span>
+                    <span />
+                </Fragment>
+                <div />
+            </Fragment>
+        </Fragment>
+    </div>
+
+    assert div.__parent__ is None
+    frag1, = div.__children__
+    assert frag1.__parent__ is div
+    frag2, = frag1.__children__
+    assert frag2.__parent__ is div
+    frag3, div2 = frag2.__children__
+    assert frag3.__parent__ is div
+    assert div2.__parent__ is div
+    span1, span2 = frag3.__children__
+    assert span1.__parent__ is div
+    assert span2.__parent__ is div
+    br, = span1.__children__
+    assert br.__parent__ is span1
+    assert len(span2.__children__) == 0

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,0 +1,29 @@
+# coding: mixt
+
+from typing import Any
+
+from mixt import Element, html
+
+
+
+def test_refs():
+
+    class Foo(Element):
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+
+            self.div_ref = self.add_ref()
+            self.span_ref = self.add_ref()
+
+        def render(self, context):
+            return <div ref={self.div_ref}><span ref={self.span_ref}></span></div>
+
+        def postrender(self, element, context):
+            self.div_ref.current.add_class('pr_div')
+            self.span_ref.current.add_class('pr_span')
+
+    assert str(<Foo />) == '<div class="pr_div"><span class="pr_span"></span></div>'
+
+
+


### PR DESCRIPTION
```python

from mixt import Element, JSSelector

class Content(Element):
    def render_js(self, context):
        return """
alert(1);
"""

    def render(self, context):
        return <div>{self.children()}</div>

class App(Element):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        self.js_ref = self.add_ref()

    def render(self, context):
        return \
            <html>
                <head>
                {lambda: self.js_ref.current.render_collected()}
                </head>
                <body>
                    <JSCollector ref={self.js_ref}>
                        <Content><p>Hello</p></Content>
                    </JSCollector>
                </body>
            </html>

assert str(<App />) == """\
<html><head><script type="text/javascript">
alert(1);
</script></head><body><div><p>Hello</p></div></body></html>"""
```